### PR TITLE
docs(onpremise): restructure on-premise guide into topic-based pages

### DIFF
--- a/misc/onpremise/README.md
+++ b/misc/onpremise/README.md
@@ -1,6 +1,8 @@
 # Cloud Connector (On-Premise) Destination
 
-This guide explains how to configure an SAP BTP destination with proxy type `OnPremise` so SAP BTP applications can securely reach on‑premise systems (such as SAP S/4HANA) using the Cloud Connector. It includes configuration examples, validation steps, troubleshooting tips, and a concise support-ticket checklist.
+This guide explains how to configure an SAP BTP destination with proxy type `OnPremise` so SAP BTP applications can securely reach on-premise systems (such as SAP S/4HANA) using the Cloud Connector.
+
+> **Important:** Ensure any HTML5 application source files you modify are under source control before making changes. Any configuration changes or scripts that alter the behaviour of your system should be carried out with the authorization of your IT support team.
 
 Table of Contents
 
@@ -8,58 +10,53 @@ Table of Contents
 - [Prerequisites](#prerequisites)
 - [How It Works](#how-it-works)
 - [Flow Diagram](#flow-diagram)
-- [Configuration Steps](#configuration-steps)
-  - [Cloud Connector Configuration](#cloud-connector-configuration)
-  - [SAP BTP Destination](#sap-btp-destination)
-- [Validate Connectivity](#validate-connectivity)
-- [Connectivity Issues & Quick Checks](#connectivity-issues--quick-checks)
-- [Enable Cloud Connector Trace Logging](#enable-cloud-connector-trace-logging)
-- [Checklist for Support Tickets](#checklist-for-support-tickets)
-- [Deployment Issues](#deployment-issues)
-  - [Unknown File Type During Upload](#unknown-file-type-during-upload)
-- [Additional Resources](#additional-resources)
-- [Known Issues](#known-issues)
-- [Principal Propagation](#principal-propagation)
-- [License](#license)
+- [Guide](#guide)
+
+---
 
 ## Overview
 
-> **Important**: Ensure any HTML5 application source files you modify are under source control before making changes. Any configuration changes or scripts that alter the behaviour of your system or operating system should be carried out with the authorization of your IT support team.
-
-An SAP BTP destination with `ProxyType=OnPremise` lets your cloud apps connect to on‑premise systems using the Cloud Connector as a secure tunnel.
+An SAP BTP destination with `ProxyType=OnPremise` lets your cloud apps connect to on-premise systems using the Cloud Connector as a secure tunnel.
 
 Use cases include:
 
-- Accessing on‑premise SAP systems such as SAP S/4HANA and SAP ECC.
+- Accessing on-premise SAP systems such as SAP S/4HANA and SAP ECC.
 - Connecting to internal databases or APIs behind a firewall.
-- Consuming APIs that are not internet‑facing.
+- Consuming APIs that are not internet-facing.
 
 Authentication options include:
 
 - Basic Authentication
 - OAuth2: Client Credentials
 - OAuth2: User Credentials
-- Principal Propagation: Recommended for end‑user identity forwarding.
+- Principal Propagation: Recommended for end-user identity forwarding.
 
 Security benefits include:
 
-- Encrypted communication between SAP BTP and on‑premise systems.
-- Support for principal propagation (end‑to‑end user identity).
+- Encrypted communication between SAP BTP and on-premise systems.
+- Support for principal propagation (end-to-end user identity).
 - No need to expose internal services directly to the internet.
+
+---
 
 ## Prerequisites
 
-- The SAP BTP Cloud Foundry runtime is configured in your subaccount.
+- SAP BTP Cloud Foundry runtime is configured in your subaccount.
 - You have access to the SAP BTP cockpit to create and modify destinations.
 - You have admin access to the Cloud Connector UI for mapping and trace logs.
-- Note: When generating SAP Fiori elements apps, ensure the OData services expose XML metadata (OData V2 or OData V4) as required by the generator.
+- When generating SAP Fiori elements apps, ensure the OData services expose XML metadata (OData V2 or OData V4) as required by the generator.
+
+---
 
 ## How It Works
 
-You create a destination in your SAP BTP subaccount that points to a Cloud Connector mapping. At runtime, your app requests the destination configuration from the destination service. If the destination uses the `OnPremise` proxy type, the request is routed through the Connectivity Service and the Cloud Connector to the on‑premise back-end.
+You create a destination in your SAP BTP subaccount that points to a Cloud Connector mapping. At runtime, your app requests the destination configuration from the destination service. If the destination uses the `OnPremise` proxy type, the request is routed through the Connectivity Service and the Cloud Connector to the on-premise back end.
+
+---
 
 ## Flow Diagram
-(If your renderer supports Mermaid, the code below renders a sequence diagram showing SAP Business Application Studio and SAP BTP -> Destination Service -> Connectivity Service -> Back End).
+
+(If your renderer supports Mermaid, the code below renders a sequence diagram.)
 
 ```mermaid
 sequenceDiagram
@@ -84,268 +81,22 @@ sequenceDiagram
    BTPApp-->>Developer: 7. Application processes and displays data
 ```
 
-## Configuration Steps
+---
 
-### Cloud Connector Configuration
+## Guide
 
-For more information about how to install and configure Cloud Connector, see [Installation and Configuration of SAP Cloud Connector](https://blogs.sap.com/2021/09/05/installation-and-configuration-of-sap-cloud-connector).
+Work through the sections in order. Each page links to the next.
 
-### SAP BTP Destination
+| Step | Page | What it covers |
+|---|---|---|
+| 1 | [Connectivity](./connectivity.md) | Configure the Cloud Connector and BTP destination, validate the back end is reachable, and resolve connectivity failures. |
+| 2 | [Deployment](./deployment.md) | Deploy your SAP Fiori app to the ABAP on-premise repository and resolve deployment errors. |
+| 3 | [Principal Propagation](./principal-propagation.md) | Configure end-user identity forwarding from SAP BTP through the Cloud Connector to the back end. |
+| 4 | [SAPUI5 Library from On-Premise](./ui5-onpremise.md) | Consume a pinned SAPUI5 version served from your on-premise system instead of the CDN. |
 
-You can import the [Cloud Connector destination](./cloudconnector) example into the SAP BTP cockpit. Below is an example of destination properties that you can use the SAP BTP cockpit to create and update:
+**Raising a ticket?** See the [Support Checklist](./support-checklist.md) for the artifacts to attach.
 
-```ini
-# SAP BTP Cloud Connector Destination Example
-Type=HTTP
-HTML5.DynamicDestination=true
-Description=SAP Cloud Connector
-Authentication=PrincipalPropagation
-CloudConnectorLocationId=scloud
-WebIDEEnabled=true
-ProxyType=OnPremise
-URL=http://my-internal-host:44330/
-Name=MyOnPremiseDestination
-WebIDEUsage=odata_abap
-HTML5.Timeout=60000
-```
-
-Properties:
-
-- `WebIDEUsage=odata_abap`: Exposes OData service catalogs to SAP Business Application Studio.
-- `WebIDEEnabled=true`: Enables the destination for SAP Business Application Studio.
-- `HTML5.Timeout`: The timeout duration in milliseconds. Example: 60000.
-- `HTML5.DynamicDestination=true`: Enables the destination to be dynamically created at runtime.
-- `Authentication=PrincipalPropagation`: Forwards the end‑user identity to the back end. This is recommended for productive landscapes.
-- `CloudConnectorLocationId`: The Cloud Connector location configured in the subaccount.
-- `URL`: The internal host and port mapped through the Cloud Connector. Update this property to match your virtual host mapping.
-
-## Validate Connectivity
-
-Run the [Environment Check](../destinations/README.md#environment-check) in SAP Business Application Studio to validate the OData V2 and OData V4 catalog endpoints. The check produces an `envcheck-results.md` file with information about any failures.
-
-Address any issues found in the environment check report before proceeding.
-
-## Connectivity Issues & Quick Checks
-
-If connectivity fails, run these quick checks first:
-
-- Is the SAP Cloud Connector running and connected to the SAP BTP subaccount?
-- Is the Cloud Connector mapping (virtual host and port and back-end host and port) configured and active?
-- Is the destination in the subaccount pointing to the correct `CloudConnectorLocationId` and name? This is required if there are multiple Cloud Connectors.
-- Are the authentication settings in the destination and back-end system aligned (such as principal propagation, SSL, and certs)?
-- Are firewalls or proxies blocking traffic between Cloud Connector and the back end? This often occurs when moving to production because the originating IPs change.
-- Are you able to locally access the back-end system directly from the Cloud Connector host such as using `curl` or a web browser?
-
-If problems persist, follow the [trace logging](./README.md#enable-cloud-connector-trace-logging) steps below to gather logs and re-run the [Environment Check report](../destinations/README.md#environment-check).
-
-## Enable Cloud Connector Trace Logging
-
-Only use trace logging for troubleshooting. This is not recommended in production in the long term.
-
-1. In the Cloud Connector UI: Log in -> `Log and Trace Files` -> `Edit`.
-2. Set `Cloud Connector Loggers` to `ALL` and `Other Loggers` to `Information`.
-3. Enable `Payload Trace` and ensure the correct subaccount is selected.
-4. Reproduce the failing scenario and capture the following logs:
-   - `ljs_trace.log` (Cloud Connector)
-   - `scc_core.log` (if present)
-   - `traffic_trace_<subaccount>_on_<region>.trc` (required)
-   - `tunnel_traffic_trace_<subaccount>_on_<region>.trc` (if applicable)
-5. After capturing, revert logging levels to avoid excessive log generation.
-
-For more information on troubleshooting, see [Monitoring, Logging, and Troubleshooting](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/cloud-connector-troubleshooting).
-
-If you do not see network traffic in the `traffic_trace_` logs, the most likely cause is that the Cloud Connector cannot establish a secure tunnel to the target system. This is often caused by a local firewall or proxy blocking the connection. For more information, see [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526).
-
-## Additional Resources
-
-- [Whitelisting SAP BTP IP ranges](https://help.sap.com/docs/bas/sap-business-application-studio/sap-business-application-studio-availability?locale=en-US#inbound-ip-address%20), requires support from your IT Admin team.
-- [Understanding SAP BTP Destinations](https://learning.sap.com/learning-journeys/administrating-sap-business-technology-platform/using-destinations)
-- [Create SAP BTP Destinations](https://developers.sap.com/tutorials/cp-cf-create-destination.html)
-- [Cloud Connector Explained](https://community.sap.com/t5/technology-blog-posts-by-sap/cloud-connector-explained-in-simple-terms/ba-p/13547036)
-- [Principal Propagation Overview and Setup Links](#principal-propagation)
-- [Consuming SAPUI5 libraries from On‑Premise](./ui5-onpremise.md)
-
-## Checklist for Support Tickets
-
-If you need to raise a support ticket (component `BC-MID-SCC` for Cloud Connector or `CA-UX-IDE` for deployment issues), attach the following items:
-
-The required artifacts, which must be compiled into a single zip file and attached to the support ticket, are:
-
-- A screenshot of the destination in the SAP BTP cockpit (show all properties).
-- [Environment Check report](../destinations/README.md#environment-check).
-- From your Cloud Connector:
-  - Subaccount Overview: Cloud Connector -> Subaccount Overview -> Click Subaccount.
-  - Virtual Host Mapping: Cloud Connector -> Cloud to On-Premise -> Select Virtual Host Mapping as defined in the SAP BTP destination.
-  - Access Control: Cloud Connector -> Cloud to On-Premise -> Access Control -> Select Mapping -> Actions -> Edit (pencil icon).
-  - Access Control: Cloud Connector -> Cloud to On-Premise -> Access Control -> Select Mapping -> Ensure "Access Policy" is set to "Path" and All Sub-Paths and URL Path is "/". Note this may differ depending on security concerns.
-  - Check Availability: Cloud Connector -> Cloud to On-Premise -> Access Control -> Actions -> Select Mapping -> Check Availability.
-  - Collected logs from trace logging (see list above).
-- Output from ABAP transaction logs `/IWFND/ERROR_LOG` and `/IWFND/GW_CLIENT`. For more information, see [SAP ABAP guide](https://www.youtube.com/watch?v=Tmb-O966GwM).
-
-Optional but helpful:
-
-- `curl` output from an SAP Business Application Studio terminal when executing the connection test. See the example below.
-- Clear reproduction steps and expected versus actual behavior.
-
-Example Connection Test (SAP Business Application Studio or any terminal window):
-
-```bash
-# Replace <destination-name> before executing
-curl -L -vs -i -H "X-CSRF-Token: Fetch" "https://<destination-name>.dest/sap/opu/odata/IWFND/CATALOGSERVICE;v=2?saml2=disabled" > curl-catalog-output.txt 2>&1
-```
-
-You can review the generated `curl-catalog-output.txt` file to check for any errors or issues related to connectivity.
-
-## Deployment Issues
-
-Before addressing any issues with deployment, ensure connectivity works as per the [Validate Connectivity](#validate-connectivity) section.
-
-### Deployment Prerequisites
-
-- Ensure that `/UI5/ABAP_REPOSITORY_SRV` has been activated in the back end.
-- Ensure that you have the required `S_DEVELOP` authorizations.
-- For more information about `/UI5/ABAP_REPOSITORY_SRV` and fulfilling these prerequisites, see [Using an OData Service to Load Data to the SAPUI5 ABAP Repository](https://ui5.sap.com/#/topic/a883327a82ef4cc792f3c1e7b7a48de8).
-
-### Debugging Deployment Errors (HTTP 401 and HTTP 403)
-
-- Review the ABAP transaction logs `/IWFND/ERROR_LOG` and `/IWFND/GW_CLIENT`, where applicable. These logs indicate missing authorizations and other local issues.
-- For more information on deployment issues, see [Deployment to ABAP On-Premise System](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:45996:50742:46000).
-
-Steps to capture deployment debug information:
-
-```bash
-# Mac / Linux
-DEBUG=* npm run deploy
-# Windows (powershell)
-set DEBUG=* && npm run deploy
-```
-
-Example Connection Test (SAP Business Application Studio or any terminal window):
-
-```bash
-# Replace <destination-name>
-# Replace bsp-name with a known BSP repository name
-curl -L -vs -i -H "X-CSRF-Token: Fetch" "https://<destination-name>.dest/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV/Repositories(%27bsp-name%27)?saml2=disabled" > curl-abap-srv-output.txt 2>&1
-```
-
-You can review the generated `curl-abap-srv-output.txt` file to check for any errors or issues related to the deployment process.
-
-#### What This Test Validates
-
-This request performs several important technical checks in a single call:
-
-##### Destination Resolution
-
-`https://<destination-name>.dest` verifies that:
-
-- The SAP BTP destination exists.
-- The destination is bound to your application (if applicable).
-- Connectivity using Cloud Connector (for On-Premise systems) works.
-
-##### Authentication Flow
-
-Confirms that the configured authentication method such as BasicAuthentication, SAML Assertion, or OAuth2 works
-
-If authentication fails, you typically see:
-
-- 401 Unauthorized: Invalid credentials or trust not established
-- 403 Forbidden: Authenticated but missing back-end authorization
-
-##### Back-End Reachability
-
-`/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` validates the following:
-
-- SAP Gateway is active.
-- The OData service is registered and active (`/IWFND/MAINT_SERVICE`).
-- The ICF node is active (`/sap/opu/odata`).
-
-##### CSRF Token Handling
-
-`-H "X-CSRF-Token: Fetch"` forces the back-end to:
-
-- Authenticate the request.
-- Issue a valid X-CSRF-Token.
-- Return any required session cookies.
-
-##### SAML Handling Control
-
-`?saml2=disabled` ensures the request does not trigger browser-based SAML redirects.
-
-This is useful when testing service-to-service flows where interactive SSO is not expected.
-
-### Additional Resources for Deployment
-
-- [Build and Deploy your SAPUI5 application using SAP Business Application Studio to ABAP repository (on-premise system)](https://community.sap.com/t5/technology-blog-posts-by-members/build-and-deploy-your-sapui5-application-using-sap-business-application/ba-p/13559538)
-
-### Unknown File Type During Upload
-
-**Error**: "Not uploaded as binary/text type is unknown: Adjust content of files."
-
-**Root cause**: The ABAP UI5 repository validates file extensions during upload. Files with extensions not listed in `.Ui5RepositoryTextFiles` or `.Ui5RepositoryBinaryFiles` are rejected with this error.
-
-**Solution**: Add the unknown file extensions to the appropriate configuration file for the repository in your project.
-
-1. Navigate to the `webapp` folder of your project:
-
-   ```
-   <projectRoot>/webapp/
-   ```
-
-2. Create the configuration files if they do not already exist:
-
-   - `.Ui5RepositoryTextFiles`: for text-based file types
-   - `.Ui5RepositoryBinaryFiles`: for binary asset types
-
-3. Add the file patterns for the unknown extensions, for example:
-
-   `.Ui5RepositoryTextFiles`:
-
-   ```
-   **/*.ts
-   **/*.yaml
-   **/*.jsonc
-   ```
-
-   `.Ui5RepositoryBinaryFiles`:
-
-   ```
-   **/*.eot
-   **/*.woff
-   **/*.ttf
-   ```
-
-4. Rebuild and redeploy the application:
-
-   ```bash
-   npm run deploy
-   ```
-
-   The build packages both configuration files into an `archive.zip` file, which allows the ABAP back-end to classify the previously unknown file types. The deployment then proceeds without the "unknown file type" error.
-
-For more information, see [Using an OData Service to Load Data to the SAPUI5 ABAP Repository](https://ui5.sap.com/#/topic/a883327a82ef4cc792f3c1e7b7a48de8).
-
-## Known Issues
-
-- The OData V4 catalog service is not available. This issue typically occurs when you receive HTTP 401, 403, and 404 exceptions. The HTTP exception may also contain the following string: `/IWFND/CONFIG not published`.
-  - [OData V4 Service Catalog Tutorial](https://community.sap.com/t5/technology-blog-posts-by-sap/odata-v4-service-catalog/ba-p/13477068)
-  - [OData V4 Service Catalog Documentation](https://help.sap.com/docs/SAP_NETWEAVER_AS_ABAP_752/68bf513362174d54b58cddec28794093/326e64dbe120405e852046afa5de2235.html)
-  - [2954378 - The Gateway Error Log shows: No authorization to access service group '/IWNGW/NOTIFICATION'](https://launchpad.support.sap.com/#/notes/0002954378)
-  - [2928752 - How to activate ICF nodes in SAP Gateway?](https://launchpad.support.sap.com/#/notes/0002928752)
-- [2489898 - HTTP 404 Not Found for /IWFND/CATALOGSERVICE and Cannot load tile on SAP Fiori Launchpad](https://me.sap.com/notes/0002489898)
-- [3378435 - Response headers too big in /UI5/UI5_REPOSITORY_LOAD](https://me.sap.com/notes/0003378435)
-
-## Principal Propagation
-
-In most on-premise configurations, principal propagation is the recommended implementation to support end-user identification. Principal propagation is an authentication mechanism used primarily in SAP Cloud and hybrid system landscapes to securely forward (or propagate) a user's identity from one system or layer to another without re-authenticating the user at each hop.
-
-For example:
-
-If a user logs into a SAP Fiori app on SAP BTP, and that app calls an on-premise SAP S/4HANA system, principal propagation allows the user's identity to be sent end-to-end, so SAP S/4HANA knows exactly which user made the request, rather than seeing a generic `technical` user.
-
-- [Setting up Principal Propagation](https://community.sap.com/t5/technology-blog-posts-by-sap/setting-up-principal-propagation/ba-p/13510251)
-- [Configuring Principal Propagation](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/configuring-principal-propagation)
-
-For more information about connectivity issues related to principal propagation configurations and to trace connectivity issues, see [How to Troubleshoot Cloud Connector Principal Propagation over HTTPS](https://help.sap.com/docs/SUPPORT_CONTENT/appservices/3361376259.html#HowtotroubleshootCloudConnectorprincipalpropagationoverHTTPS-Checkingthelogs,followtheclientcertificate).
+---
 
 ## License
 

--- a/misc/onpremise/connectivity.md
+++ b/misc/onpremise/connectivity.md
@@ -1,0 +1,140 @@
+# Connectivity
+
+This page covers how to configure the SAP BTP destination and the Cloud Connector, validate that your on-premise back end is reachable, and resolve connectivity failures.
+
+Table of Contents
+
+- [Cloud Connector Configuration](#cloud-connector-configuration)
+- [SAP BTP Destination](#sap-btp-destination)
+- [Validate Connectivity](#validate-connectivity)
+- [Quick Checks](#quick-checks)
+- [Enable Cloud Connector Trace Logging](#enable-cloud-connector-trace-logging)
+- [Known Issues](#known-issues)
+- [Additional Resources](#additional-resources)
+
+---
+
+## Cloud Connector Configuration
+
+For more information about how to install and configure the Cloud Connector, see [Installation and Configuration of SAP Cloud Connector](https://blogs.sap.com/2021/09/05/installation-and-configuration-of-sap-cloud-connector).
+
+The Cloud Connector must be:
+
+- Running and connected to your SAP BTP subaccount.
+- Configured with a virtual host mapping that points to your on-premise back-end host and port.
+- Set up with access control entries that allow requests from SAP BTP to reach the mapped paths.
+
+---
+
+## SAP BTP Destination
+
+You can import the [Cloud Connector destination](./cloudconnector) example into the SAP BTP cockpit. Below is an example of destination properties:
+
+```ini
+# SAP BTP Cloud Connector Destination Example
+Type=HTTP
+HTML5.DynamicDestination=true
+Description=SAP Cloud Connector
+Authentication=PrincipalPropagation
+CloudConnectorLocationId=scloud
+WebIDEEnabled=true
+ProxyType=OnPremise
+URL=http://my-internal-host:44330/
+Name=MyOnPremiseDestination
+WebIDEUsage=odata_abap
+HTML5.Timeout=60000
+```
+
+Properties:
+
+- `WebIDEUsage=odata_abap`: Exposes OData service catalogs to SAP Business Application Studio.
+- `WebIDEEnabled=true`: Enables the destination for SAP Business Application Studio.
+- `HTML5.Timeout`: The timeout duration in milliseconds. Example: `60000`.
+- `HTML5.DynamicDestination=true`: Enables the destination to be dynamically resolved at runtime.
+- `Authentication=PrincipalPropagation`: Forwards the end-user identity to the back end. Recommended for productive landscapes. See [Principal Propagation](./principal-propagation.md).
+- `CloudConnectorLocationId`: The Cloud Connector location configured in the subaccount. Required when multiple Cloud Connectors are registered.
+- `URL`: The internal host and port mapped through the Cloud Connector. Update this to match your virtual host mapping.
+
+---
+
+## Validate Connectivity
+
+Run the [Environment Check](../destinations/README.md#environment-check) in SAP Business Application Studio to validate the OData V2 and OData V4 catalog endpoints. The check produces an `envcheck-results.md` file with details on any failures.
+
+Address any issues in the report before proceeding to [Deployment](./deployment.md).
+
+You can also run a manual connection test from an SAP Business Application Studio terminal:
+
+```bash
+# Replace <destination-name> before executing
+curl -L -vs -i -H "X-CSRF-Token: Fetch" "https://<destination-name>.dest/sap/opu/odata/IWFND/CATALOGSERVICE;v=2?saml2=disabled" > curl-catalog-output.txt 2>&1
+```
+
+Review `curl-catalog-output.txt` to check for connectivity or authentication errors.
+
+---
+
+## Quick Checks
+
+If connectivity fails, run these checks first:
+
+- Is the Cloud Connector running and connected to the SAP BTP subaccount?
+- Is the virtual host mapping (virtual host/port and back-end host/port) configured and active?
+- Does the destination point to the correct `CloudConnectorLocationId`?
+- Are the authentication settings in the destination and the back-end system aligned (such as principal propagation, SSL, and certificates)?
+- Are firewalls or proxies blocking traffic between the Cloud Connector and the back end? This often occurs when moving to production because the originating IPs change.
+- Can you access the back-end system directly from the Cloud Connector host using `curl` or a web browser?
+
+If problems persist, follow the [trace logging](#enable-cloud-connector-trace-logging) steps below to gather logs and re-run the [Environment Check report](../destinations/README.md#environment-check).
+
+---
+
+## Enable Cloud Connector Trace Logging
+
+> Only use trace logging for troubleshooting. This is not recommended in production on a long-term basis.
+
+1. In the Cloud Connector UI: **Log In** > **Log and Trace Files** > **Edit**.
+2. Set **Cloud Connector Loggers** to `ALL` and **Other Loggers** to `Information`.
+3. Enable **Payload Trace** and ensure the correct subaccount is selected.
+4. Reproduce the failing scenario and capture the following logs:
+   - `ljs_trace.log` (Cloud Connector)
+   - `scc_core.log` (if present)
+   - `traffic_trace_<subaccount>_on_<region>.trc` (required)
+   - `tunnel_traffic_trace_<subaccount>_on_<region>.trc` (if applicable)
+5. After capturing logs, revert logging levels to avoid excessive log generation.
+
+For more information, see [Monitoring, Logging, and Troubleshooting](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/cloud-connector-troubleshooting).
+
+If you do not see network traffic in the `traffic_trace_` logs, the most likely cause is that the Cloud Connector cannot establish a secure tunnel to the target system. This is often caused by a local firewall or proxy. For more information, see [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526).
+
+---
+
+## Known Issues
+
+### OData V4 Catalog Service Not Available
+
+**Symptoms:** HTTP 401, HTTP 403, or HTTP 404 responses. The error may contain the string `/IWFND/CONFIG not published`.
+
+**Resources:**
+
+- [OData V4 Service Catalog Tutorial](https://community.sap.com/t5/technology-blog-posts-by-sap/odata-v4-service-catalog/ba-p/13477068)
+- [OData V4 Service Catalog Documentation](https://help.sap.com/docs/SAP_NETWEAVER_AS_ABAP_752/68bf513362174d54b58cddec28794093/326e64dbe120405e852046afa5de2235.html)
+- [SAP Note 2954378 - No authorization to access service group '/IWNGW/NOTIFICATION'](https://launchpad.support.sap.com/#/notes/0002954378)
+- [SAP Note 2928752 - How to activate ICF nodes in SAP Gateway](https://launchpad.support.sap.com/#/notes/0002928752)
+
+### OData V2 Catalog Returns HTTP 404
+
+- [SAP Note 2489898 - HTTP 404 Not Found for /IWFND/CATALOGSERVICE and Cannot load tile on SAP Fiori Launchpad](https://me.sap.com/notes/0002489898)
+
+---
+
+## Additional Resources
+
+- [Whitelisting SAP BTP IP ranges](https://help.sap.com/docs/bas/sap-business-application-studio/sap-business-application-studio-availability?locale=en-US#inbound-ip-address%20) — requires support from your IT admin team
+- [Understanding SAP BTP Destinations](https://learning.sap.com/learning-journeys/administrating-sap-business-technology-platform/using-destinations)
+- [Create SAP BTP Destinations](https://developers.sap.com/tutorials/cp-cf-create-destination.html)
+- [Cloud Connector Explained](https://community.sap.com/t5/technology-blog-posts-by-sap/cloud-connector-explained-in-simple-terms/ba-p/13547036)
+
+---
+
+**Next:** [Deployment](./deployment.md) — deploy your app to the ABAP on-premise repository.

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -1,0 +1,157 @@
+# Deployment
+
+This page covers how to deploy your SAP Fiori app to an on-premise ABAP repository using the SAP BTP destination. Before starting, confirm that [connectivity works](./connectivity.md).
+
+Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Debugging Deployment Errors (HTTP 401 and HTTP 403)](#debugging-deployment-errors-http-401-and-http-403)
+- [Connection Test](#connection-test)
+  - [What the Test Validates](#what-the-test-validates)
+- [Unknown File Type During Upload](#unknown-file-type-during-upload)
+- [Known Issues](#known-issues)
+- [Additional Resources](#additional-resources)
+
+---
+
+## Prerequisites
+
+Before deploying, confirm the following on your back-end system:
+
+- `/UI5/ABAP_REPOSITORY_SRV` is activated.
+- You have the required `S_DEVELOP` authorizations.
+
+For more information, see [Using an OData Service to Load Data to the SAPUI5 ABAP Repository](https://ui5.sap.com/#/topic/a883327a82ef4cc792f3c1e7b7a48de8).
+
+---
+
+## Debugging Deployment Errors (HTTP 401 and HTTP 403)
+
+- Review the ABAP transaction logs `/IWFND/ERROR_LOG` and `/IWFND/GW_CLIENT`. These logs indicate missing authorizations and other local issues.
+- For more information, see [Deployment to ABAP On-Premise System](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:45996:50742:46000).
+
+To capture verbose deployment debug output:
+
+```bash
+# Mac / Linux
+DEBUG=* npm run deploy
+
+# Windows (PowerShell)
+set DEBUG=* && npm run deploy
+```
+
+---
+
+## Connection Test
+
+Run this test from an SAP Business Application Studio terminal to confirm the deployment endpoint is reachable before running `npm run deploy`:
+
+```bash
+# Replace <destination-name> and bsp-name before executing
+curl -L -vs -i -H "X-CSRF-Token: Fetch" "https://<destination-name>.dest/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV/Repositories(%27bsp-name%27)?saml2=disabled" > curl-abap-srv-output.txt 2>&1
+```
+
+Review `curl-abap-srv-output.txt` for authentication, authorization, or connectivity errors.
+
+### What the Test Validates
+
+#### Destination resolution
+
+`https://<destination-name>.dest` verifies that:
+
+- The SAP BTP destination exists.
+- The destination is bound to your application (if applicable).
+- Connectivity using the Cloud Connector (for on-premise systems) works.
+
+#### Authentication flow
+
+Confirms that the configured authentication method (such as BasicAuthentication, SAML Assertion, or OAuth2) works.
+
+If authentication fails, you typically see:
+
+- `401 Unauthorized`: Invalid credentials or trust not established.
+- `403 Forbidden`: Authenticated but missing back-end authorization.
+
+#### Back-end reachability
+
+`/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` validates:
+
+- SAP Gateway is active.
+- The OData service is registered and active (`/IWFND/MAINT_SERVICE`).
+- The ICF node is active (`/sap/opu/odata`).
+
+#### CSRF token handling
+
+`-H "X-CSRF-Token: Fetch"` forces the back end to authenticate the request, issue a valid CSRF token, and return any required session cookies.
+
+#### SAML handling control
+
+`?saml2=disabled` prevents browser-based SAML redirects, which is useful when testing service-to-service flows where interactive SSO is not expected.
+
+---
+
+## Unknown File Type During Upload
+
+**Error:** "Not uploaded as binary/text type is unknown: Adjust content of files."
+
+**Root cause:** The ABAP UI5 repository validates file extensions during upload. Files with extensions not listed in `.Ui5RepositoryTextFiles` or `.Ui5RepositoryBinaryFiles` are rejected.
+
+**Solution:** Add the unknown extensions to the appropriate configuration file in your project.
+
+1. Navigate to the `webapp` folder of your project:
+
+   ```
+   <projectRoot>/webapp/
+   ```
+
+2. Create the configuration files if they do not already exist:
+
+   - `.Ui5RepositoryTextFiles`: for text-based file types
+   - `.Ui5RepositoryBinaryFiles`: for binary asset types
+
+3. Add the file patterns for the unknown extensions:
+
+   `.Ui5RepositoryTextFiles`:
+
+   ```
+   **/*.ts
+   **/*.yaml
+   **/*.jsonc
+   ```
+
+   `.Ui5RepositoryBinaryFiles`:
+
+   ```
+   **/*.eot
+   **/*.woff
+   **/*.ttf
+   ```
+
+4. Rebuild and redeploy the application:
+
+   ```bash
+   npm run deploy
+   ```
+
+   The build packages both configuration files into `archive.zip`, which allows the ABAP back end to classify the previously unknown file types. The deployment then proceeds without the error.
+
+For more information, see [Using an OData Service to Load Data to the SAPUI5 ABAP Repository](https://ui5.sap.com/#/topic/a883327a82ef4cc792f3c1e7b7a48de8).
+
+---
+
+## Known Issues
+
+- [SAP Note 3378435 - Response headers too big in /UI5/UI5_REPOSITORY_LOAD](https://me.sap.com/notes/0003378435)
+
+---
+
+## Additional Resources
+
+- [Build and Deploy your SAPUI5 Application Using SAP Business Application Studio to ABAP Repository (on-premise system)](https://community.sap.com/t5/technology-blog-posts-by-members/build-and-deploy-your-sapui5-application-using-sap-business-application/ba-p/13559538)
+- [Support Checklist](./support-checklist.md) — what to attach when raising a support ticket
+
+---
+
+**Previous:** [Connectivity](./connectivity.md) — configure and validate your Cloud Connector and BTP destination.
+
+**Next:** [Principal Propagation](./principal-propagation.md) — configure end-user identity forwarding to the back end.

--- a/misc/onpremise/principal-propagation.md
+++ b/misc/onpremise/principal-propagation.md
@@ -1,0 +1,163 @@
+# Principal Propagation
+
+Principal propagation is the recommended authentication method for productive on-premise landscapes. It forwards the logged-in user's identity from SAP BTP through the Cloud Connector to the back-end system — so the back end sees the actual user, not a generic technical account.
+
+**When to use it:** Any time your back-end system needs to know which user is making a request, for example, for authorization checks, audit logs, or personalization.
+
+Table of Contents
+
+- [How It Works](#how-it-works)
+- [Prerequisites](#prerequisites)
+- [Step 1: Configure Trust in the SAP BTP Subaccount](#step-1-configure-trust-in-the-sap-btp-subaccount)
+- [Step 2: Configure the Cloud Connector](#step-2-configure-the-cloud-connector)
+- [Step 3: Configure the Back-End System](#step-3-configure-the-back-end-system)
+- [Step 4: Configure the SAP BTP Destination](#step-4-configure-the-sap-btp-destination)
+- [Step 5: Validate Principal Propagation](#step-5-validate-principal-propagation)
+- [Troubleshooting](#troubleshooting)
+- [Additional Resources](#additional-resources)
+
+---
+
+## How It Works
+
+1. The user authenticates with SAP BTP (for example, via SAML or OIDC).
+2. SAP BTP issues a short-lived client certificate representing the user.
+3. The Cloud Connector presents this certificate to the on-premise back end.
+4. The back end maps the certificate subject to a local user account and processes the request under that identity.
+
+The key requirement is **trust**: the back end must trust the Cloud Connector's system certificate, and the Cloud Connector must be allowed to assert user identities on behalf of SAP BTP.
+
+---
+
+## Prerequisites
+
+- SAP BTP subaccount is configured with Cloud Foundry runtime.
+- Cloud Connector is installed, running, and connected to the subaccount.
+- You have admin access to: the SAP BTP cockpit, the Cloud Connector UI, and the ABAP back-end system (transaction `STRUST`, `SM59`, `SU01`/`SU10`).
+- [Connectivity works](./connectivity.md): confirm the back end is reachable before configuring PP.
+
+---
+
+## Step 1: Configure Trust in the SAP BTP Subaccount
+
+The subaccount certificate is used by the Cloud Connector to identify itself to the back end. You need to download it and import it into the back end.
+
+1. In the SAP BTP cockpit, navigate to **Connectivity** > **Cloud Connectors**.
+2. Select your connected Cloud Connector and expand the **Subaccount** details.
+3. Under **Subaccount Certificate**, download the certificate (`.pem` or `.crt` format).
+
+Keep this certificate — you will import it into the back end in [Step 3](#step-3-configure-the-back-end-system).
+
+---
+
+## Step 2: Configure the Cloud Connector
+
+Enable the Cloud Connector to issue short-lived user certificates for principal propagation.
+
+1. In the Cloud Connector UI, navigate to **Configuration** > **On Premise** > **Principal Propagation**.
+2. Under **Subject Pattern**, configure how the user identity is encoded in the certificate subject. A common pattern is:
+
+   ```
+   CN=${name}
+   ```
+
+   Where `${name}` maps to the SAP BTP user's login name. Adjust the pattern to match how users are identified in your back-end system (for example, by email, by SAP user ID, or by a custom attribute).
+
+3. Set the **Certificate Validity** (the lifetime of the short-lived certificate). A value of 60 seconds is typical for production.
+
+4. Save the configuration.
+
+For the full list of available subject pattern variables, see [Configuring Principal Propagation](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/configuring-principal-propagation).
+
+---
+
+## Step 3: Configure the Back-End System
+
+The ABAP back end must trust the Cloud Connector's system certificate and map the incoming certificate subject to a local user.
+
+### 3a. Import the System Certificate into STRUST
+
+1. In the ABAP system, open transaction `STRUST`.
+2. Navigate to **SSL server Standard** (or the relevant SSL node for your system).
+3. Import the subaccount certificate downloaded in [Step 1](#step-1-configure-trust-in-the-sap-btp-subaccount) into the certificate list.
+4. Save and activate.
+
+### 3b. Configure User Mapping
+
+The back end must map the certificate subject (for example, `CN=john.doe@company.com`) to a local ABAP user.
+
+For systems using **SAP Logon Tickets** or **X.509 client certificates**:
+
+1. Open transaction `SU01` (for individual users) or `SU10` (for mass changes).
+2. In the user record, go to the **Logon Data** tab.
+3. Set **User Type** to `System` or `Dialog` as appropriate.
+4. Under the **SNC** tab, set the **SNC Name** to match the principal propagation subject pattern configured in the Cloud Connector. For example:
+
+   ```
+   p:CN=john.doe@company.com, OU=SAP BTP, O=SAP SE
+   ```
+
+   The exact format depends on your Cloud Connector subject pattern. Check the Cloud Connector trace log (see [Troubleshooting](#troubleshooting)) to see the exact subject string being presented.
+
+---
+
+## Step 4: Configure the SAP BTP Destination
+
+Set the destination authentication to `PrincipalPropagation`:
+
+```ini
+Type=HTTP
+Authentication=PrincipalPropagation
+ProxyType=OnPremise
+URL=http://my-internal-host:44330/
+Name=MyOnPremiseDestination
+CloudConnectorLocationId=scloud
+WebIDEEnabled=true
+WebIDEUsage=odata_abap
+HTML5.DynamicDestination=true
+HTML5.Timeout=60000
+```
+
+> Do not set `User` or `Password` properties when using `PrincipalPropagation` — authentication is handled via certificate.
+
+---
+
+## Step 5: Validate Principal Propagation
+
+Run the [Environment Check](../destinations/README.md#environment-check) in SAP Business Application Studio. The check runs a catalog request using the configured destination and confirms the end-user identity is forwarded correctly.
+
+You can also test manually from an SAP Business Application Studio terminal:
+
+```bash
+# Replace <destination-name> before executing
+curl -L -vs -i -H "X-CSRF-Token: Fetch" "https://<destination-name>.dest/sap/opu/odata/IWFND/CATALOGSERVICE;v=2?saml2=disabled" > curl-pp-output.txt 2>&1
+```
+
+A successful response returns HTTP 200 with a catalog payload. If you see HTTP 401 or HTTP 403, proceed to [Troubleshooting](#troubleshooting).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| HTTP 401 on catalog request | Trust not established between Cloud Connector and back end | Re-check `STRUST` — confirm the subaccount certificate is imported and active |
+| HTTP 403 on catalog request | User mapped but missing back-end authorization | Check `S_SERVICE` and `S_RFC` authorizations for the mapped user in `SU53` |
+| `SNC name not found` error in logs | Subject pattern mismatch between Cloud Connector and back-end SNC name | Enable [trace logging](./connectivity.md#enable-cloud-connector-trace-logging) and compare the presented subject with the `SNC Name` in `SU01` |
+| HTTP 200 but wrong user in back end | Subject pattern maps to wrong attribute | Adjust subject pattern in Cloud Connector and confirm back-end `SNC Name` values match |
+
+For step-by-step log analysis, see [How to Troubleshoot Cloud Connector Principal Propagation over HTTPS](https://help.sap.com/docs/SUPPORT_CONTENT/appservices/3361376259.html#HowtotroubleshootCloudConnectorprincipalpropagationoverHTTPS-Checkingthelogs,followtheclientcertificate).
+
+---
+
+## Additional Resources
+
+- [Setting up Principal Propagation](https://community.sap.com/t5/technology-blog-posts-by-sap/setting-up-principal-propagation/ba-p/13510251)
+- [Configuring Principal Propagation](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/configuring-principal-propagation)
+- [How to Troubleshoot Cloud Connector Principal Propagation over HTTPS](https://help.sap.com/docs/SUPPORT_CONTENT/appservices/3361376259.html#HowtotroubleshootCloudConnectorprincipalpropagationoverHTTPS-Checkingthelogs,followtheclientcertificate)
+
+---
+
+**Previous:** [Deployment](./deployment.md) — deploy your app to the ABAP on-premise repository.
+
+**Next:** [SAPUI5 Library from On-Premise](./ui5-onpremise.md) — consume a pinned SAPUI5 version from your on-premise system.

--- a/misc/onpremise/support-checklist.md
+++ b/misc/onpremise/support-checklist.md
@@ -1,0 +1,58 @@
+# Support Checklist
+
+If connectivity or deployment issues persist after working through the troubleshooting steps, raise a support ticket. Use the component `BC-MID-SCC` for Cloud Connector issues or `CA-UX-IDE` for deployment issues.
+
+Compile all required artifacts into a single zip file and attach it to the ticket.
+
+---
+
+## Required Artifacts
+
+### SAP BTP Destination
+
+- Screenshot of the destination in the SAP BTP cockpit (show all properties, including additional properties).
+
+### Environment Check Report
+
+- [Environment Check report](../destinations/README.md#environment-check) generated from SAP Business Application Studio.
+
+### Cloud Connector Screenshots
+
+Capture the following screens from the Cloud Connector UI:
+
+- **Subaccount Overview:** Cloud Connector > Subaccount Overview > click the subaccount.
+- **Virtual Host Mapping:** Cloud Connector > Cloud to On-Premise > select the virtual host mapping defined in the SAP BTP destination.
+- **Access Control (edit view):** Cloud Connector > Cloud to On-Premise > Access Control > select the mapping > Actions > Edit (pencil icon).
+- **Access Control (access policy):** Cloud Connector > Cloud to On-Premise > Access Control > select the mapping. Confirm **Access Policy** is set to **Path and All Sub-Paths** and the URL path is `/`. This may differ depending on your security requirements.
+- **Check Availability result:** Cloud Connector > Cloud to On-Premise > Access Control > Actions > Check Availability.
+
+### Cloud Connector Logs
+
+Collected trace logs (see [Enable Cloud Connector Trace Logging](./connectivity.md#enable-cloud-connector-trace-logging)):
+
+- `ljs_trace.log`
+- `scc_core.log` (if present)
+- `traffic_trace_<subaccount>_on_<region>.trc`
+- `tunnel_traffic_trace_<subaccount>_on_<region>.trc` (if applicable)
+
+### ABAP Transaction Logs
+
+- Output from `/IWFND/ERROR_LOG` and `/IWFND/GW_CLIENT`. For more information, see the [SAP ABAP guide](https://www.youtube.com/watch?v=Tmb-O966GwM).
+
+---
+
+## Optional but Helpful
+
+- `curl` output from an SAP Business Application Studio terminal when executing the connection test:
+
+  ```bash
+  # Replace <destination-name> before executing
+  curl -L -vs -i -H "X-CSRF-Token: Fetch" "https://<destination-name>.dest/sap/opu/odata/IWFND/CATALOGSERVICE;v=2?saml2=disabled" > curl-catalog-output.txt 2>&1
+  ```
+
+- Clear reproduction steps with expected versus actual behavior.
+- SAP BTP subaccount ID and region.
+
+---
+
+**Back to:** [Overview](./README.md)

--- a/misc/onpremise/ui5-onpremise.md
+++ b/misc/onpremise/ui5-onpremise.md
@@ -1,22 +1,30 @@
-# Exposing an SAPUI5 Library from an On-Premise System
+# Consuming an SAPUI5 Library from an On-Premise System
 
-You can consume an SAPUI5 library from an On-Premise system by configuring the `ui5.yaml` file in your project to include the On-Premise system to expose the SAPUI5 library. This is useful when the specific SAPUI5 version you want to use is not available on the SAPUI5 CDN network. 
+You can consume an SAPUI5 library from an on-premise system by configuring the `ui5.yaml` file in your project to point to a destination that exposes the library. This is useful when the specific SAPUI5 version you need is not available on the SAPUI5 CDN.
 
+Table of Contents
 
-# Prerequisites
-- The SAPUI5 library must be accessible from the On-Premise system.
-- The On-Premise system must be reachable from the environment where the SAPUI5 application is running. In this example, it is SAP Business Application Studio using the Cloud Connector.
-- The SAPUI5 version is not available on the SAPUI5 CDN network. For example, https://ui5.sap.com/1.71.53 returns a HTTP 404 Not Found response. For a full list of available versions, see [SAPUI5 Versions](https://ui5.sap.com/versionoverview.html).
+- [Prerequisites](#prerequisites)
+- [Existing Setup](#existing-setup)
+- [Duplicate the SAP BTP Destination](#duplicate-the-sap-btp-destination)
+- [Validate the Duplicated Destination](#validate-the-duplicated-destination)
+- [Modify the ui5.yaml File](#modify-the-ui5yaml-file)
 
-# Configuration Steps
+---
+
+## Prerequisites
+
+- The SAPUI5 library is accessible from the on-premise system.
+- The on-premise system is reachable from SAP Business Application Studio using the Cloud Connector. See [Connectivity](./connectivity.md) if not yet configured.
+- The SAPUI5 version you need is not available on the CDN. For example, `https://ui5.sap.com/1.71.53` returns HTTP 404. For a full list of available versions, see [SAPUI5 Versions](https://ui5.sap.com/versionoverview.html).
+
+---
 
 ## Existing Setup
 
-To start, you already have a `ui5.yaml` file in your project which points to an existing SAP BTP destination.
+You already have a `ui5.yaml` file that points to an existing SAP BTP destination. In this example, the destination is called `MyDestination` and is configured as follows:
 
-In this example, your SAP BTP destination is called `MyDestination` and the On-Premise system is reachable using the Cloud Connector and is configured as follows:
-
-```JSON
+```json
 {
     "destination": {
         "Authentication": "NoAuthentication",
@@ -34,7 +42,7 @@ In this example, your SAP BTP destination is called `MyDestination` and the On-P
 }
 ```
 
-Your SAPUI5 HTML5 application is generated with a `ui5.yaml` configuration, pointing to the UI5 CDN and the destination `MyDestination`:
+Your `ui5.yaml` points to the UI5 CDN and the destination:
 
 ```yaml
 # yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
@@ -53,7 +61,7 @@ server:
           path:
             - /resources
             - /test-resources
-          url: https://ui5.sap.com           
+          url: https://ui5.sap.com
         backend:
           - path: /sap
             url: http://my-internal-system.abc.internal:443
@@ -71,11 +79,13 @@ server:
           theme: sap_fiori_3
 ```
 
+---
+
 ## Duplicate the SAP BTP Destination
 
-To expose the SAPUI5 library from the On-Premise system, duplicate the SAP BTP destination configuration in your SAP BTP subaccount and change the URL.
+Create a second destination that points to the SAPUI5 library path on the on-premise system:
 
-```JSON
+```json
 {
     "destination": {
         "Authentication": "NoAuthentication",
@@ -85,31 +95,33 @@ To expose the SAPUI5 library from the On-Premise system, duplicate the SAP BTP d
         "Name": "MyDestination_ui5",
         "ProxyType": "OnPremise",
         "Type": "HTTP",
-        "URL": "http://my-internal-system.abc.internal:443/sap/public/bc/ui5_ui5/1/",       
+        "URL": "http://my-internal-system.abc.internal:443/sap/public/bc/ui5_ui5/1/",
         "sap-client": "100"
     }
 }
 ```
 
-The SAP BTP destination `URL` is configured with the following path: `/sap/public/bc/ui5_ui5/1/`. This is the path where the SAPUI5 libraries are exposed from the On-Premise system. The path may differ depending on your On-Premise system configuration so check with your system administrator if this path is correct.
+The `URL` includes the path `/sap/public/bc/ui5_ui5/1/` where SAPUI5 libraries are exposed on the on-premise system. Confirm this path with your system administrator — it may differ depending on your system configuration.
 
-**Note:** `WebIDEUsage` is not required for this destination because it is not exposing any OData services and is only used to serve the SAPUI5 library.
+> `WebIDEUsage` is not required for this destination because it exposes the SAPUI5 library only, not an OData service.
 
-## Validate Duplicated Destination
+---
 
-In SAP Business Application Studio, you can validate the duplicated destination: `MyDestination_ui5` by using the `curl` command to fetch the SAPUI5 library from the On-Premise system:
+## Validate the Duplicated Destination
+
+From an SAP Business Application Studio terminal, confirm the library is accessible:
 
 ```bash
- curl -L 'https://mydestination_ui5.dest/resources/sap-ui-core.js' -X GET -i -H 'X-Csrf-Token: fetch' > output-tsk1.txt
+curl -L 'https://mydestination_ui5.dest/resources/sap-ui-core.js' -X GET -i -H 'X-Csrf-Token: fetch' > output-tsk1.txt
 ```
 
-You can review the generated `output-tsk1.txt` file to ensure the SAPUI5 library is accessible from the On-Premise system. The response should contain the SAPUI5 library content.
+Review `output-tsk1.txt` — a successful response contains the SAPUI5 library content.
 
-## Modify the `ui5.yaml` File
+---
 
-To allow the SAPUI5 library to be consumed from the On-Premise system, you need to modify the `ui5.yaml` file in your project to include the destination:
+## Modify the ui5.yaml File
 
-It's important that the `/test-resources` is updated to point to the SAPUI5 CDN, while the `/resources` path is updated to point to the On-Premise system destination. This allows you to use the SAPUI5 library from the On-Premise system while still being able to access test resources from the SAPUI5 CDN. You should choose the version that is the closest to the version you are using in your project.
+Update `ui5.yaml` to serve `/resources` from the on-premise destination and `/test-resources` from the CDN:
 
 ```yaml
         ui5:
@@ -121,7 +133,7 @@ It's important that the `/test-resources` is updated to point to the SAPUI5 CDN,
               url: https://ui5.sap.com/<valid-UI5-version>
 ```
 
-For an example of the entire `ui5.yaml` file, see the following code sample:
+For the full `ui5.yaml`, see the example below:
 
 ```yaml
 # yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
@@ -139,10 +151,10 @@ server:
         ui5:
           version: ''
           paths:
-            - path: /resources          
-              url: https://mydestination_ui5.dest                    
+            - path: /resources
+              url: https://mydestination_ui5.dest
             - path: /test-resources
-              url: https://ui5.sap.com/1.71.76                
+              url: https://ui5.sap.com/1.71.76
         backend:
           - path: /sap
             url: http://my-internal-system.abc.internal:443
@@ -160,13 +172,18 @@ server:
           theme: sap_fiori_3
 ```
 
-**Note the following:**
-- The SAPUI5 `version` property is configured with an empty string. This prevents rewriting the SAPUI5 paths to include the version number because this is not required.
-- The SAPUI5 paths `/test-resources` and `/resources` are configured to point to different locations.
+Notes:
 
-The reason the SAP BTP destination was duplicated was to allow you to control the path to the SAPUI5 library. This can point to any URI that exposes the SAPUI5 library.
+- The `version` property is set to an empty string to prevent the tooling from rewriting the SAPUI5 paths to include a version number.
+- `/resources` and `/test-resources` point to different locations intentionally — the on-premise system serves the pinned library version, while the CDN serves test resources for a supported version.
 
-### License
-Copyright (c) 2009-2026 SAP SE or an SAP affiliate company. This project is licensed under the Apache Software License, version 2.0 except as noted otherwise in the [LICENSE](../../LICENSES/Apache-2.0.txt) file.
+---
 
+**Previous:** [Principal Propagation](./principal-propagation.md)  
+**Raising a ticket?** See the [Support Checklist](./support-checklist.md).
 
+---
+
+## License
+
+Copyright (c) 2009-2026 SAP SE or an SAP affiliate company. This project is licensed under the Apache License 2.0. See [LICENSE](../../LICENSES/Apache-2.0.txt) for details.


### PR DESCRIPTION
## Summary

- Splits the monolithic `misc/onpremise/README.md` (354 lines) into four focused sub-pages: `connectivity.md`, `deployment.md`, `principal-propagation.md`, and `support-checklist.md`
- `README.md` is rewritten as an index with a sequential navigation table — developers can work through the guide step by step
- `principal-propagation.md` expands the previous 2-link stub into a full 5-step walkthrough (trust, Cloud Connector config, STRUST/SU01, destination config, validation + troubleshooting table)
- All files pass KM documentation review (heading case, list markers, terminology, Oxford comma, em dash rules)

## Test Plan

- [ ] Verify all internal links resolve correctly (connectivity.md → deployment.md → principal-propagation.md → ui5-onpremise.md)
- [ ] Verify `support-checklist.md` links back to README and connectivity trace logging section
- [ ] Confirm markdown lints clean: `npx markdownlint misc/onpremise/*.md`
- [ ] Review README navigation table renders correctly on GitHub