### PR TITLE
docs(km): apply KM fixes and expand abapcloud destination guide

### DIFF
--- a/misc/abapcloud/README.md
+++ b/misc/abapcloud/README.md
@@ -1,22 +1,23 @@
 # SAP BTP ABAP Environment (Steampunk)
 
-
-# Prerequisites
+## Prerequisites
 
 > **Important**: Ensure any HTML5 application source files you modify are under source control before making changes. Any configuration scripts or commands that change the behaviour of your system or operating system should be carried out with the authorization of your IT support team.
 
-- The `Authentication` type can be configured with different options which include `OAuth2UserTokenExchange` and `SAMLAssertion`.
-- When exposing an SAP BTP ABAP Environment (Steampunk) system to the internet using a SAP BTP destination, ensure the destination `WebIDEUsage` field contains the following values: 
-```
+- The `Authentication` type can be configured with different options, including `OAuth2UserTokenExchange` and `SAMLAssertion`.
+- When exposing an SAP BTP ABAP Environment (Steampunk) system to the internet using an SAP BTP destination, ensure the destination `WebIDEUsage` field contains the following values:
+
+```text
 WebIDEUsage: odata_abap,dev_abap,abap_cloud
 ```
+
 The `abap_cloud` property is used to determine which type of system is being connected to.
 
 ## Understanding ABAP Cloud Environment (Steampunk)
 
 Follow this blog post to [Demystifying: SAP BTP - ABAP Environment, Steampunk, ABAP on Cloud, Embedded Steampunk](https://community.sap.com/t5/technology-blog-posts-by-members/demystifying-sap-btp-abap-environment-steampunk-abap-on-cloud-embedded/ba-p/13567772).
 
-## Creating a SAP Fiori App and Deploy it to SAP BTP, ABAP Cloud Environment
+## Creating an SAP Fiori App and Deploying It to SAP BTP, ABAP Cloud Environment
 
 Follow this tutorial to [Create an SAP Fiori App and Deploy it to SAP BTP, ABAP Environment](https://developers.sap.com/tutorials/abap-environment-deploy-fiori-elements-ui.html).
 
@@ -24,11 +25,98 @@ Follow this tutorial to [Create an SAP Fiori App and Deploy it to SAP BTP, ABAP 
 
 Option 1: Watch [Configuring BTP Cross-Account and Cross-Region Destinations For Use in UI Tooling](https://www.youtube.com/watch?v=8ePyQJsmWYA).
 
-Please note some of the content is outdated. For example, the legacy SAP BTP Destinations flow or where to find the trust (*.pem file) certificates. However, the video is still relevant for the cross-account and cross-region destination configuration.
+Note that some of the content is outdated. For example, the legacy SAP BTP Destinations flow or where to find the trust (*.pem file) certificates. However, the video is still relevant for the cross-account and cross-region destination configuration.
 
 Option 2: Read [Creating a Destination for Cross-Subaccount Communication](https://help.sap.com/docs/btp/sap-business-technology-platform/creating-destination-for-cross-subaccount-communication)
 
-# Troubleshooting
+### Key Notes from the Tutorial
+
+#### Connectivity overview
+
+SAP Business Application Studio connects to ABAP systems using BTP destinations. The typical flow for ABAP Cloud is: BAS connects to a destination, which connects to the ABAP Environment using BTP. Destinations must be correctly configured with the authentication type, trust configuration, and correct service exposure.
+
+#### Destination configuration
+
+The destination must point to the ABAP system root URL, not a specific service path. Key required properties include:
+
+- `WebIDEUsage`: `odata_abap,dev_abap,abap_cloud`
+- Correct root URL with no service path appended
+- Proper authentication type based on the scenario:
+  - Same subaccount: `OAuth2UserTokenExchange`
+  - Cross-subaccount: `SAMLAssertion`
+
+The following is an example of an `OAuth2UserTokenExchange` destination for an ABAP Cloud system (same-subaccount scenario):
+
+```json
+{
+    "Authentication": "OAuth2UserTokenExchange",
+    "HTML5.DynamicDestination": "true",
+    "HTML5.SetXForwardedHeaders": "false",
+    "HTML5.Timeout": "180000",
+    "Name": "<destination-name>",
+    "ProxyType": "Internet",
+    "Type": "HTTP",
+    "URL": "https://<abap-system-guid>.abap.<region>.ondemand.com",
+    "WebIDEEnabled": "true",
+    "WebIDEUsage": "odata_abap,dev_abap,abap_cloud",
+    "abap_enabled": "true",
+    "clientId": "<client-id>",
+    "clientSecret": "<client-secret>",
+    "tokenServiceURL": "https://<subdomain>.authentication.<region>.hana.ondemand.com/oauth/token",
+    "tokenServiceURLType": "Dedicated"
+}
+```
+
+The following is an example of a `SAMLAssertion` destination for a cross-subaccount scenario:
+
+```json
+{
+    "Authentication": "SAMLAssertion",
+    "Description": "<destination-description>",
+    "HTML5.DynamicDestination": "true",
+    "HTML5.Timeout": "60000",
+    "Name": "<destination-name>",
+    "ProxyType": "Internet",
+    "Type": "HTTP",
+    "URL": "https://<system-id>-api.<region>.ondemand.com",
+    "WebIDEEnabled": "true",
+    "WebIDEUsage": "odata_abap,dev_abap,abap_cloud",
+    "audience": "https://<system-id>.<region>.ondemand.com",
+    "authnContextClassRef": "urn:oasis:names:tc:SAML:2.0:ac:classes:PreviousSession",
+    "nameIdFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+}
+```
+
+#### Cross-subaccount requirements
+
+When BAS (Subaccount B) accesses an ABAP system (Subaccount A), both subaccounts must be under the same global account and trust must be established between them. The identity provider and trust configuration must be aligned so that tokens issued in Subaccount B are accepted by Subaccount A.
+
+The SAML trust must be explicitly established between the two subaccounts. This requires exporting the signing certificate from Subaccount B (the identity provider context) and importing it into Subaccount A within the ABAP Cloud system.
+
+In the ABAP environment, this is configured using the Communication Systems application, where the certificate is uploaded and assigned to the relevant communication system. This ensures that SAML assertions issued by Subaccount B can be validated and trusted by Subaccount A during authentication.
+
+#### Roles and authorizations
+
+The developer user must have the required business roles and catalogs assigned in the ABAP system. For example, the `SAP_A4C_BC_DEV_UID_PC` role is required for UI deployment. Missing roles typically result in HTTP 401 (authorization failure) or HTTP 500 (back-end configuration issue) errors.
+
+#### Service discovery
+
+BAS uses OData catalog services to discover back-end services. Both V2 and V4 catalog endpoints must be accessible:
+
+- V2: `/sap/opu/odata/IWFND/CATALOGSERVICE`
+- V4: `/sap/opu/odata4/.../catalog`
+
+An empty catalog or connection failure typically indicates a destination misconfiguration, authentication failure, or missing service exposure in the ABAP communication scenario.
+
+#### Common failure patterns
+
+| HTTP Status | Likely Cause |
+|---|---|
+| HTTP 401 | Missing roles, invalid authentication setup, or SAML trust not configured |
+| HTTP 500 | Back-end misconfiguration, missing service exposure, or invalid destination setup |
+| Empty catalog | Service not exposed in ABAP or communication scenario not configured |
+
+## Troubleshooting
 
 One of the most common reasons why the connection fails when accessing the ABAP Cloud environment from an external application, such as Business Application Studio, is that the communication system is not set up correctly.
 
@@ -36,6 +124,6 @@ For more information, see [Creating a Communication System for SAP Business Appl
 
 If you are still blocked from accessing your ABAP Cloud instance, enable a connectivity trace in your ABAP Cloud system and analyze the error. For more information, see [Enable a Connectivity Trace](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/display-connectivity-trace).
 
-### License
-Copyright (c) 2009-2026 SAP SE or an SAP affiliate company. This project is licensed under the Apache Software License, version 2.0 except as noted otherwise in the [LICENSE](../../LICENSES/Apache-2.0.txt) file.
+## License
 
+Copyright (c) 2009-2026 SAP SE or an SAP affiliate company. This project is licensed under the Apache Software License, version 2.0 except as noted otherwise in the [LICENSE](../../LICENSES/Apache-2.0.txt) file.

--- a/misc/abapcloud/README.md
+++ b/misc/abapcloud/README.md
@@ -126,11 +126,11 @@ One of the most common reasons why the connection fails when accessing the ABAP 
 
 For more information, see [Creating a Communication System for SAP Business Application Studio](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/creating-communication-system-for-sap-business-application-studio).
 
-### Validating connectivity using Environment Check
+### Validating Connectivity Using Environment Check
 
 Use the Environment Check tool in BAS to validate your destination properties and confirm connectivity. For more information, see the [Environment Check](../destinations/README.md#environment-check) section in the destinations guide.
 
-### Enabling a connectivity trace
+### Enabling a Connectivity Trace
 
 If you are still blocked after reviewing the Environment Check report, enable a connectivity trace in your ABAP Cloud system and analyze the error. For more information, see [Enable a Connectivity Trace](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/display-connectivity-trace).
 

--- a/misc/abapcloud/README.md
+++ b/misc/abapcloud/README.md
@@ -128,19 +128,7 @@ For more information, see [Creating a Communication System for SAP Business Appl
 
 ### Validating connectivity using Environment Check
 
-The Environment Check tool in BAS is the recommended first step for validating your destination configuration and connectivity. It checks whether the destination is reachable and whether the OData V2 and V4 catalog endpoints are accessible.
-
-1. Open SAP Business Application Studio.
-2. Open the Command Palette (**View** > **Find Command**).
-3. Enter `Fiori: Open Environment Check`.
-4. Click **Check Destination** and select your destination.
-5. Enter credentials, if prompted.
-6. Click **Save and view results**.
-7. A `Preview results.md` file opens. Review the **Destination Details** section for missing parameters or catalog failures.
-
-For more information, see [Environment Check](https://help.sap.com/docs/SAP_FIORI_tools/17d50220bcd848aa854c9c182d65b699/75390cf5d81e43aea5db231ef4225268.html).
-
-The Environment Check report also generates a zip file containing destination configuration details, debug trace logs, and the list of services exposed by the destination. If you need to open a support ticket, attach the full zip file to help the support team diagnose the issue.
+Use the Environment Check tool in BAS to validate your destination properties and confirm connectivity. For more information, see the [Environment Check](../destinations/README.md#environment-check) section in the destinations guide.
 
 ### Enabling a connectivity trace
 

--- a/misc/abapcloud/README.md
+++ b/misc/abapcloud/README.md
@@ -33,13 +33,17 @@ Option 2: Read [Creating a Destination for Cross-Subaccount Communication](https
 
 #### Connectivity overview
 
-SAP Business Application Studio connects to ABAP systems using BTP destinations. The typical flow for ABAP Cloud is: BAS connects to a destination, which connects to the ABAP Environment using BTP. Destinations must be correctly configured with the authentication type, trust configuration, and correct service exposure.
+SAP Business Application Studio connects to ABAP Cloud systems using BTP destinations configured with `WebIDEUsage=odata_abap`. The typical flow is: BAS connects to a destination, which connects to the ABAP Environment using BTP. With `odata_abap`, the destination URL must always be the base host only — BAS appends the ABAP catalog paths automatically.
+
+Before connecting, ensure BAS is logged in to Cloud Foundry and the correct organization and space are set. This is required for BAS to resolve destinations and deploy applications correctly.
 
 #### Destination configuration
 
-The destination must point to the ABAP system root URL, not a specific service path. Key required properties include:
+The destination must point to the ABAP system root URL with no service path appended. Key required properties include:
 
 - `WebIDEUsage`: `odata_abap,dev_abap,abap_cloud`
+- `WebIDEEnabled`: `true`
+- `HTML5.DynamicDestination`: `true`
 - Correct root URL with no service path appended
 - Proper authentication type based on the scenario:
   - Same subaccount: `OAuth2UserTokenExchange`
@@ -101,12 +105,12 @@ The developer user must have the required business roles and catalogs assigned i
 
 #### Service discovery
 
-BAS uses OData catalog services to discover back-end services. Both V2 and V4 catalog endpoints must be accessible:
+BAS uses OData catalog services to discover back-end services. With `odata_abap`, both V2 and V4 catalog endpoints must be accessible from the destination:
 
 - V2: `/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/ServiceCollection`
 - V4: `/sap/opu/odata4/iwfnd/config/default/iwfnd/catalog/0002/ServiceGroups?$expand=DefaultSystem($expand=Services)`
 
-An empty catalog or connection failure typically indicates a destination misconfiguration, authentication failure, or missing service exposure in the ABAP communication scenario.
+An empty catalog or connection failure typically indicates a destination misconfiguration, authentication failure, or a missing service exposure in the ABAP communication scenario.
 
 #### Common failure patterns
 
@@ -122,7 +126,25 @@ One of the most common reasons why the connection fails when accessing the ABAP 
 
 For more information, see [Creating a Communication System for SAP Business Application Studio](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/creating-communication-system-for-sap-business-application-studio).
 
-If you are still blocked from accessing your ABAP Cloud instance, enable a connectivity trace in your ABAP Cloud system and analyze the error. For more information, see [Enable a Connectivity Trace](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/display-connectivity-trace).
+### Validating connectivity using Environment Check
+
+The Environment Check tool in BAS is the recommended first step for validating your destination configuration and connectivity. It checks whether the destination is reachable and whether the OData V2 and V4 catalog endpoints are accessible.
+
+1. Open SAP Business Application Studio.
+2. Open the Command Palette (**View** > **Find Command**).
+3. Enter `Fiori: Open Environment Check`.
+4. Click **Check Destination** and select your destination.
+5. Enter credentials, if prompted.
+6. Click **Save and view results**.
+7. A `Preview results.md` file opens. Review the **Destination Details** section for missing parameters or catalog failures.
+
+For more information, see [Environment Check](https://help.sap.com/docs/SAP_FIORI_tools/17d50220bcd848aa854c9c182d65b699/75390cf5d81e43aea5db231ef4225268.html).
+
+The Environment Check report also generates a zip file containing destination configuration details, debug trace logs, and the list of services exposed by the destination. If you need to open a support ticket, attach the full zip file to help the support team diagnose the issue.
+
+### Enabling a connectivity trace
+
+If you are still blocked after reviewing the Environment Check report, enable a connectivity trace in your ABAP Cloud system and analyze the error. For more information, see [Enable a Connectivity Trace](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/display-connectivity-trace).
 
 ## License
 

--- a/misc/abapcloud/README.md
+++ b/misc/abapcloud/README.md
@@ -103,8 +103,8 @@ The developer user must have the required business roles and catalogs assigned i
 
 BAS uses OData catalog services to discover back-end services. Both V2 and V4 catalog endpoints must be accessible:
 
-- V2: `/sap/opu/odata/IWFND/CATALOGSERVICE`
-- V4: `/sap/opu/odata4/.../catalog`
+- V2: `/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/ServiceCollection`
+- V4: `/sap/opu/odata4/iwfnd/config/default/iwfnd/catalog/0002/ServiceGroups?$expand=DefaultSystem($expand=Services)`
 
 An empty catalog or connection failure typically indicates a destination misconfiguration, authentication failure, or missing service exposure in the ABAP communication scenario.
 


### PR DESCRIPTION
## Summary

- Fixes all markdownlint issues in `misc/abapcloud/README.md` (multiple H1s, bare code fence, trailing spaces, missing blank lines)
- Applies KM standards: H4 sentence case, `via` → `using`, `a SAP` → `an SAP`, `Please note` → `Note that`, missing comma, code fence language tag
- Expands the cross-account destination section with a new **Key Notes from the Tutorial** subsection covering:
  - Connectivity overview
  - Destination configuration with `OAuth2UserTokenExchange` and `SAMLAssertion` example JSON (obfuscated)
  - Cross-subaccount requirements including SAML trust certificate export/import via Communication Systems
  - Roles and authorizations
  - Service discovery (V2/V4 catalog endpoints)
  - Common failure patterns table (HTTP 401, HTTP 500, empty catalog)

## Test plan

- [ ] `npx markdownlint-cli misc/abapcloud/README.md` passes with no output
- [ ] All destination examples use obfuscated placeholder values
- [ ] KM heading case: H1–H3 title case, H4+ sentence case
- [ ] No `via` usage remains; no `a SAP` article errors remain