### PR TITLE
docs: update Utilities category in README to list all misc subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains samples organized by technology and use case:
 | **Third-party Libraries** | Adding external libraries to Fiori apps | [thirdpartylibrary/](thirdpartylibrary/) |
 | **Generator Extensions** | Extending @sap/generator-fiori | [sample-fiori-gen-ext/](sample-fiori-gen-ext/) |
 | **Migration** | Neo to Cloud Foundry migration | [neo-migration/](neo-migration/) |
-| **Utilities** | Destinations, on-premise connectivity, ABAP Cloud, S/4HANA, SuccessFactors, headless generator, proxy, SSL certificates, CI/CD, npm dependency management, and SAP Fiori tools generator | [misc/](misc/) |
+| **Utilities** | Destinations, on-premise connectivity, ABAP Cloud (Steampunk), S/4HANA, SuccessFactors, headless generator, proxy, SSL certificates, CI/CD, npm dependency management, and SAP Fiori tools generator | [misc/](misc/) |
 
 [View complete sample catalog](SAMPLES_INDEX.md) for detailed descriptions and direct links.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Explore [V4 samples](V4/) for the latest OData V4 and Fiori elements features.
 
 ### Advanced Use Cases
 
-Check [misc/](misc/) for destinations, on-premise connectivity, ABAP Cloud, S/4HANA, SuccessFactors, headless generator, proxy, SSL certificates, CI/CD, npm dependency management, and SAP Fiori tools generator guidance.
+Check [misc/](misc/) for destinations, on-premise connectivity, ABAP Cloud (Steampunk), S/4HANA, SuccessFactors, headless generator, proxy, SSL certificates, CI/CD, npm dependency management, and SAP Fiori tools generator guidance.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains samples organized by technology and use case:
 | **Third-party Libraries** | Adding external libraries to Fiori apps | [thirdpartylibrary/](thirdpartylibrary/) |
 | **Generator Extensions** | Extending @sap/generator-fiori | [sample-fiori-gen-ext/](sample-fiori-gen-ext/) |
 | **Migration** | Neo to Cloud Foundry migration | [neo-migration/](neo-migration/) |
-| **Utilities** | Proxy, destinations, npm management, CI/CD, and SuccessFactors connectivity | [misc/](misc/) |
+| **Utilities** | Destinations, on-premise connectivity, ABAP Cloud, S/4HANA, SuccessFactors, headless generator, proxy, SSL certificates, CI/CD, npm dependency management, and SAP Fiori tools generator | [misc/](misc/) |
 
 [View complete sample catalog](SAMPLES_INDEX.md) for detailed descriptions and direct links.
 
@@ -38,7 +38,7 @@ Explore [V4 samples](V4/) for the latest OData V4 and Fiori elements features.
 
 ### Advanced Use Cases
 
-Check [misc/](misc/) for proxy configuration, destinations, CI/CD, npm dependency management, and on-premise connectivity.
+Check [misc/](misc/) for destinations, on-premise connectivity, ABAP Cloud, S/4HANA, SuccessFactors, headless generator, proxy, SSL certificates, CI/CD, npm dependency management, and SAP Fiori tools generator guidance.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

- Updates the Utilities row in the overview table to list all 11 subfolders in `misc/`: destinations, on-premise connectivity, ABAP Cloud, S/4HANA, SuccessFactors, headless generator, proxy, SSL certificates, CI/CD, npm dependency management, and SAP Fiori tools generator
- Updates the matching Advanced Use Cases blurb to reflect the same complete list

## Test plan

- [ ] Utilities row in overview table lists all `misc/` subfolders
- [ ] Advanced Use Cases section matches the updated description