### PR TITLE
docs(onpremise): improve connection test and trace logging sections

### DIFF
--- a/misc/onpremise/connectivity.md
+++ b/misc/onpremise/connectivity.md
@@ -165,7 +165,7 @@ If you do not see network traffic in the `traffic_trace_` logs, the most likely 
 
 ## Additional Resources
 
-- [Whitelisting SAP BTP IP ranges](https://help.sap.com/docs/bas/sap-business-application-studio/sap-business-application-studio-availability?locale=en-US#inbound-ip-address%20): requires support from your IT admin team
+- [Allowlisting SAP BTP IP Ranges](https://help.sap.com/docs/bas/sap-business-application-studio/sap-business-application-studio-availability?locale=en-US#inbound-ip-address%20): requires support from your IT admin team
 - [Understanding SAP BTP Destinations](https://learning.sap.com/learning-journeys/administrating-sap-business-technology-platform/using-destinations)
 - [Create SAP BTP Destinations](https://developers.sap.com/tutorials/cp-cf-create-destination.html)
 - [Cloud Connector Explained](https://community.sap.com/t5/technology-blog-posts-by-sap/cloud-connector-explained-in-simple-terms/ba-p/13547036)

--- a/misc/onpremise/connectivity.md
+++ b/misc/onpremise/connectivity.md
@@ -117,6 +117,8 @@ If problems persist, follow the [trace logging](#enable-cloud-connector-trace-lo
 
 ## Enable Cloud Connector Trace Logging
 
+### SAP Cloud Connector Trace Logs
+
 > Only use trace logging for troubleshooting. This is not recommended in production on a long-term basis.
 
 1. In the Cloud Connector UI: **Log In** > **Log and Trace Files** > **Edit**.
@@ -131,9 +133,11 @@ If problems persist, follow the [trace logging](#enable-cloud-connector-trace-lo
 
 For more information, see [Monitoring, Logging, and Troubleshooting](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/cloud-connector-troubleshooting).
 
+### ABAP Transaction Logs
+
 If HTTP traffic is reaching the ABAP system but errors persist, review the ABAP transaction logs for more detailed error information. This is useful when the request is not being blocked by the Cloud Connector, a local firewall, or a proxy:
 
-- Transaction codes: `/IWFND/ERROR_LOG` or `/IWFND/GW_CLIENT`
+- Transaction code: `/IWFND/ERROR_LOG`
 - Video guide: [OData Error Log Analysis](https://www.youtube.com/watch?v=Tmb-O966GwM)
 
 If you do not see network traffic in the `traffic_trace_` logs, the most likely cause is that the Cloud Connector cannot establish a secure tunnel to the target system. This is often caused by a local firewall or proxy. For more information, see [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526).

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -81,6 +81,8 @@ Invoke-WebRequest -Uri "https://<internal-host>:<internal-port>/sap/opu/odata/UI
 ```
 
 > **Note:** The `?saml2=disabled` parameter is not required when accessing the system locally. Add it only when testing through an SAP BTP destination to prevent browser-based SAML redirects in service-to-service flows.
+>
+> You can also paste the URL directly into a browser in private or incognito mode to perform a quick reachability check. However, the browser bypasses local proxy and firewall settings in some configurations, which may mask connectivity issues that `curl` or PowerShell would surface.
 
 Review `curl-abap-srv-output.txt` for authentication, authorization, or connectivity errors.
 

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -88,7 +88,7 @@ Review `curl-abap-srv-output.txt` for authentication, authorization, or connecti
 
 ### What the Test Validates
 
-#### Destination resolution
+#### Destination Resolution
 
 `https://<destination-name>.dest` verifies that:
 
@@ -96,7 +96,7 @@ Review `curl-abap-srv-output.txt` for authentication, authorization, or connecti
 - The destination is bound to your application (if applicable).
 - Connectivity using the Cloud Connector (for on-premise systems) works.
 
-#### Authentication flow
+#### Authentication Flow
 
 Confirms that the configured authentication method (such as BasicAuthentication, SAML Assertion, or OAuth2) works.
 
@@ -105,7 +105,7 @@ If authentication fails, you typically see:
 - `401 Unauthorized`: Invalid credentials or trust not established.
 - `403 Forbidden`: Authenticated but missing back-end authorization.
 
-#### Back-end reachability
+#### Back-End Reachability
 
 `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` validates:
 
@@ -113,7 +113,7 @@ If authentication fails, you typically see:
 - The OData service is registered and active (`/IWFND/MAINT_SERVICE`).
 - The ICF node is active (`/sap/opu/odata`).
 
-#### CSRF token handling
+#### CSRF Token Handling
 
 `-H "X-CSRF-Token: Fetch"` forces the back end to authenticate the request, issue a valid CSRF token, and return any required session cookies.
 
@@ -129,7 +129,7 @@ If authentication fails, you typically see:
 
 1. Navigate to the `webapp` folder of your project:
 
-   ```
+   ```text
    <projectRoot>/webapp/
    ```
 
@@ -142,7 +142,7 @@ If authentication fails, you typically see:
 
    `.Ui5RepositoryTextFiles`:
 
-   ```
+   ```text
    **/*.ts
    **/*.yaml
    **/*.jsonc
@@ -150,7 +150,7 @@ If authentication fails, you typically see:
 
    `.Ui5RepositoryBinaryFiles`:
 
-   ```
+   ```text
    **/*.eot
    **/*.woff
    **/*.ttf
@@ -177,7 +177,7 @@ For more information, see [Using an OData Service to Load Data to the SAPUI5 ABA
 ## Additional Resources
 
 - [Build and Deploy your SAPUI5 Application Using SAP Business Application Studio to ABAP Repository (on-premise system)](https://community.sap.com/t5/technology-blog-posts-by-members/build-and-deploy-your-sapui5-application-using-sap-business-application/ba-p/13559538)
-- [Support Checklist](./support-checklist.md) — what to attach when raising a support ticket
+- [Support Checklist](./support-checklist.md): what to attach when raising a support ticket
 
 ---
 

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -44,12 +44,41 @@ set DEBUG=* && npm run deploy
 
 ## Connection Test
 
-Run this test from an SAP Business Application Studio terminal to confirm the deployment endpoint is reachable before running `npm run deploy`:
+Run this test to confirm the deployment endpoint is reachable before running `npm run deploy`.
+
+### Validating on SAP Business Application Studio
+
+Run the following from an SAP Business Application Studio terminal:
 
 ```bash
 # Replace <destination-name> and bsp-name before executing
+# If authentication is required, add: -u "username:password"
 curl -L -vs -i -H "X-CSRF-Token: Fetch" "https://<destination-name>.dest/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV/Repositories(%27bsp-name%27)?saml2=disabled" > curl-abap-srv-output.txt 2>&1
 ```
+
+### Validating on Your Local Network
+
+Run the following from a local terminal, replacing `<internal-host>`, `<internal-port>`, and `bsp-name` with your system values:
+
+```bash
+# Replace <internal-host>, <internal-port>, and bsp-name before executing
+# If authentication is required, add: -u "username:password"
+curl -L -vs -i -H "X-CSRF-Token: Fetch" "https://<internal-host>:<internal-port>/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV/Repositories(%27bsp-name%27)" > curl-abap-srv-output.txt 2>&1
+```
+
+On Windows, use the following PowerShell command instead:
+
+```powershell
+# Replace <internal-host>, <internal-port>, and bsp-name before executing
+# If authentication is required, add: -Credential (Get-Credential) or -Headers @{ "Authorization" = "Basic <base64(username:password)>" }
+Invoke-WebRequest -Uri "https://<internal-host>:<internal-port>/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV/Repositories('%27bsp-name%27)" `
+  -Headers @{ "X-CSRF-Token" = "Fetch" } `
+  -MaximumRedirection 10 `
+  -OutFile curl-abap-srv-output.txt `
+  -Verbose *>&1 | Out-File curl-abap-srv-output.txt
+```
+
+> **Note:** The `?saml2=disabled` parameter is not required when accessing the system locally. Add it only when testing through an SAP BTP destination to prevent browser-based SAML redirects in service-to-service flows.
 
 Review `curl-abap-srv-output.txt` for authentication, authorization, or connectivity errors.
 
@@ -83,10 +112,6 @@ If authentication fails, you typically see:
 #### CSRF token handling
 
 `-H "X-CSRF-Token: Fetch"` forces the back end to authenticate the request, issue a valid CSRF token, and return any required session cookies.
-
-#### SAML handling control
-
-`?saml2=disabled` prevents browser-based SAML redirects, which is useful when testing service-to-service flows where interactive SSO is not expected.
 
 ---
 

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -44,7 +44,9 @@ set DEBUG=* && npm run deploy
 
 ## Connection Test
 
-Run this test to confirm the deployment endpoint is reachable before running `npm run deploy`.
+Run this test to confirm the deployment endpoint is reachable before running `npm run deploy`. This is a connectivity check only — it issues a single HTTP GET request against `ABAP_REPOSITORY_SRV`.
+
+The `bsp-name` placeholder in the URL identifies the target BSP application. Its value does not affect connectivity validation — substitute a known application name if one is available, or leave it as `bsp-name`. An HTTP 404 response when using the placeholder is expected and confirms that the endpoint is reachable but no application named `bsp-name` is deployed on the target system. Any HTTP 2xx or 4xx response indicates a live connection; HTTP 5xx or no response indicates a connectivity or configuration issue.
 
 ### Validating on SAP Business Application Studio
 


### PR DESCRIPTION
## Summary

- Split **Enable Cloud Connector Trace Logging** into two subheadings: SAP Cloud Connector Trace Logs and ABAP Transaction Logs; removed `/IWFND/GW_CLIENT` from the transaction code entry
- Split **Connection Test** into two subheadings: Validating on SAP Business Application Studio and Validating on Your Local Network
- Added PowerShell command for Windows users in the local network section, using `<internal-host>:<internal-port>` instead of `<destination-name>.dest`
- Removed `?saml2=disabled` from local network commands; added a note clarifying it is only needed for BTP destination flows
- Added credential comments to both bash and PowerShell commands

## Test Plan

- [ ] Verify markdown linting passes (`./scripts/lint-markdown.sh misc/onpremise/connectivity.md` and `deployment.md`)
- [ ] Confirm bash and PowerShell commands render correctly in preview
- [ ] Check subheadings appear in the ToC if one is present