### PR TITLE
docs: add README to V2 and V4 directories

### DIFF
--- a/V2/README.md
+++ b/V2/README.md
@@ -1,0 +1,19 @@
+# V2 Samples
+
+SAP Fiori elements sample applications using OData V2 services.
+
+## Samples
+
+| Sample | Description |
+|--------|-------------|
+| [Sales Order](apps/salesorder/) | List Report Object Page using the Northwind OData V2 service, TypeScript |
+| [Products Review](apps/products-review/) | List Report Object Page with product review functionality |
+| [Store Overview](apps/store-overview/) | List Report Object Page for store overview |
+
+## Getting Started
+
+1. Navigate to a sample directory
+2. Run `npm install`
+3. Run `npm start`
+
+For mock data, run `npm run start-mock`.

--- a/V4/README.md
+++ b/V4/README.md
@@ -1,0 +1,17 @@
+# V4 Samples
+
+SAP Fiori elements sample applications using OData V4 services.
+
+## Samples
+
+| Sample | Description |
+|--------|-------------|
+| [Travel App](apps/travel/) | List Report Object Page using the SAP UX mock travel service, TypeScript |
+
+## Getting Started
+
+1. Navigate to a sample directory
+2. Run `npm install`
+3. Run `npm start`
+
+For mock data, run `npm run start-mock`.


### PR DESCRIPTION
## Summary

- Adds `V2/README.md` listing all V2 OData samples with descriptions and links
- Adds `V4/README.md` listing all V4 OData samples with descriptions and links

This also fixes the GitHub UI path collapsing issue where `V4` was displaying as `V4/apps/travel` instead of a top-level folder, caused by having no files at the `V4/` root level.

## Test plan

- [ ] Verify GitHub repo shows `V2` and `V4` as top-level folders, not collapsed paths