### PR TITLE
chore: add destination property to V2 and V4 proxy configs

### DIFF
--- a/V2/apps/salesorder/ui5-local.yaml
+++ b/V2/apps/salesorder/ui5-local.yaml
@@ -44,6 +44,7 @@ server:
         backend:
           - path: /V2
             url: https://services.odata.org
+            destination: northwind
     - name: sap-fe-mockserver
       beforeMiddleware: csp
       configuration:

--- a/V2/apps/salesorder/ui5-mock.yaml
+++ b/V2/apps/salesorder/ui5-mock.yaml
@@ -18,6 +18,7 @@ server:
         backend:
           - path: /V2
             url: https://services.odata.org
+            destination: northwind
     - name: fiori-tools-appreload
       afterMiddleware: compression
       configuration:

--- a/V2/apps/salesorder/ui5.yaml
+++ b/V2/apps/salesorder/ui5.yaml
@@ -18,6 +18,7 @@ server:
         backend:
           - path: /V2
             url: https://services.odata.org
+            destination: northwind
     - name: fiori-tools-appreload
       afterMiddleware: compression
       configuration:

--- a/V4/apps/travel/ui5-deploy.yaml
+++ b/V4/apps/travel/ui5-deploy.yaml
@@ -18,6 +18,7 @@ builder:
         target:
           url: https://658bd07a-eda6-40bc-b17a-b9a8b79b646b.abap.canaryaws.hanavlab.ondemand.com
           authenticationType: reentranceTicket # SAML support for vscode
+          destination: sap-ux-mock-services-v4
         app:
           name: TRAVELAPP
           description: Travel App

--- a/V4/apps/travel/ui5-local.yaml
+++ b/V4/apps/travel/ui5-local.yaml
@@ -41,6 +41,7 @@ server:
         backend:
           - path: /sap
             url: https://sap-ux-mock-services-v4-lrop.cfapps.us10.hana.ondemand.com
+            destination: sap-ux-mock-services-v4
     - name: sap-fe-mockserver
       beforeMiddleware: csp
       configuration:

--- a/V4/apps/travel/ui5-mock.yaml
+++ b/V4/apps/travel/ui5-mock.yaml
@@ -18,6 +18,7 @@ server:
         backend:
           - path: /sap
             url: https://sap-ux-mock-services-v4-lrop.cfapps.us10.hana.ondemand.com
+            destination: sap-ux-mock-services-v4
     - name: fiori-tools-appreload
       afterMiddleware: compression
       configuration:

--- a/V4/apps/travel/ui5.yaml
+++ b/V4/apps/travel/ui5.yaml
@@ -18,6 +18,7 @@ server:
         backend:
           - path: /sap
             url: https://sap-ux-mock-services-v4-lrop.cfapps.us10.hana.ondemand.com
+            destination: sap-ux-mock-services-v4
     - name: fiori-tools-appreload
       afterMiddleware: compression
       configuration:


### PR DESCRIPTION
## Summary
- Added `destination: sap-ux-mock-services-v4` to backend entries in V4 travel app (`ui5.yaml`, `ui5-local.yaml`, `ui5-mock.yaml`, `ui5-deploy.yaml`)
- Added `destination: northwind` to backend entries in V2 salesorder app (`ui5.yaml`, `ui5-local.yaml`, `ui5-mock.yaml`)

## Test Plan
- [ ] Verify V4 travel app proxy resolves via `sap-ux-mock-services-v4` destination
- [ ] Verify V2 salesorder app proxy resolves via `northwind` destination