### PR TITLE
docs: add Create a SAPUI5/SAP Fiori Freestyle App tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ See [SECURITY.md](.github/SECURITY.md) for reporting security vulnerabilities.
 - [SAP Open UX Tools](https://github.com/SAP/open-ux-tools)
 - [SAP Developer Center](https://developers.sap.com/)
 - [SAP UI5 SDK](https://sapui5.hana.ondemand.com/)
+- [Create a SAPUI5/SAP Fiori Freestyle App](https://discovery-center.cloud.sap/card/3fdc5280-bf00-4764-97ab-fdc10bd1542b)
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds [Create a SAPUI5/SAP Fiori Freestyle App](https://discovery-center.cloud.sap/card/3fdc5280-bf00-4764-97ab-fdc10bd1542b) to the Additional Resources section in `README.md`
- Applicable to any SAP Fiori template type, not just freestyle

## Test Plan

- [ ] Verify link renders correctly in README
- [ ] Confirm link resolves to the SAP Discovery Center tutorial card