### PR TITLE
docs: improve on-premise deployment prerequisites and debugging guide

### DIFF
--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -16,21 +16,26 @@ Table of Contents
 
 ## Prerequisites
 
-Before deploying, confirm the following on your back-end system:
+To use the OData service `/UI5/ABAP_REPOSITORY_SRV` to upload an SAPUI5 application, component, or library to the SAPUI5 ABAP repository, ensure the following requirements are met:
 
-- `/UI5/ABAP_REPOSITORY_SRV` is activated.
-- You have the required `S_DEVELOP` authorizations.
+- Activate the `/UI5/ABAP_REPOSITORY_SRV` service in your back-end system.
+- You have `S_DEVELOP` authorisation in your back-end system.
+- For SAP BTP destinations, ensure the `HTML5.Timeout` property is configured with a minimum value of `60000`.
 
-For more information, see [Using an OData Service to Load Data to the SAPUI5 ABAP Repository](https://ui5.sap.com/#/topic/a883327a82ef4cc792f3c1e7b7a48de8).
+More information about `/UI5/ABAP_REPOSITORY_SRV` and completing these prerequisites can be found [here](https://ui5.sap.com/#/topic/a883327a82ef4cc792f3c1e7b7a48de8).
+
+Any errors during deployment are reported in the HTTP status reports, either success or errors which may have occurred during the operation. The response header or the response body contains additional information, and below is a list of common issues when deploying to an ABAP target system.
 
 ---
 
 ## Debugging Deployment Errors (HTTP 401 and HTTP 403)
 
-- Review the ABAP transaction logs `/IWFND/ERROR_LOG` and `/IWFND/GW_CLIENT`. These logs indicate missing authorizations and other local issues.
-- For more information, see [Deployment to ABAP On-Premise System](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:45996:50742:46000).
+- **HTTP 401 Unauthorized** — authentication failed. Check credentials, destination configuration, and trust setup.
+- **HTTP 403 Forbidden** — authenticated but missing back-end authorization. Verify `S_DEVELOP` authorisation for your user.
 
-To capture verbose deployment debug output:
+Review the ABAP transaction log `/IWFND/ERROR_LOG` for missing authorization details and other back-end issues.
+
+To debug on the client side, capture verbose deployment output by setting the `DEBUG` environment variable before running the deploy command:
 
 ```bash
 # Mac / Linux
@@ -39,6 +44,11 @@ DEBUG=* npm run deploy
 # Windows (PowerShell)
 set DEBUG=* && npm run deploy
 ```
+
+**Resources**
+
+- [Deployment to ABAP On-Premise System](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:45996:50742:46000)
+- Video guide: [Analyzing the `/IWFND/ERROR_LOG` OData Error Log](https://www.youtube.com/watch?v=Tmb-O966GwM)
 
 ---
 


### PR DESCRIPTION
## Summary

- Expands Prerequisites section with `HTML5.Timeout` requirement, updated `S_DEVELOP` wording, and an HTTP status reports note
- Restructures Debugging section with explicit HTTP 401/403 explanations, removes `/IWFND/GW_CLIENT`, and adds a Resources block with video guide link
- Adds client-side debug instructions context to the `DEBUG=*` command block

## Test plan

- [ ] Review rendered markdown in GitHub
- [ ] Verify all links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)