### PR TITLE
docs: add before-raising-a-ticket section to on-premise README

### DIFF
--- a/misc/onpremise/README.md
+++ b/misc/onpremise/README.md
@@ -98,6 +98,20 @@ Work through the sections in order. Each page links to the next.
 
 ---
 
+## Before Raising a Ticket
+
+Complete the following before opening a support ticket:
+
+1. **Environment check** — run the [Environment Check](../destinations/README.md#environment-check) report from SAP Business Application Studio and confirm there are no errors.
+2. **Deployment prerequisites** — confirm all [Prerequisites](./deployment.md#prerequisites) are met, including `S_DEVELOP` authorisation and `HTML5.Timeout` configuration.
+3. **Failing OData services** — enable trace logging to capture detailed error output:
+   - [Cloud Connector trace logs](./connectivity.md#enable-cloud-connector-trace-logging) for connectivity issues.
+   - [ABAP transaction logs](./connectivity.md#abap-transaction-logs) (`/IWFND/ERROR_LOG`) for back-end authorization and service errors.
+
+If the issue persists, see the [Support Checklist](./support-checklist.md) for artifacts to attach to the ticket.
+
+---
+
 ## License
 
 Copyright (c) 2009-2026 SAP SE or an SAP affiliate company.

--- a/misc/onpremise/support-checklist.md
+++ b/misc/onpremise/support-checklist.md
@@ -37,7 +37,7 @@ Collected trace logs (see [Enable Cloud Connector Trace Logging](./connectivity.
 
 ### ABAP Transaction Logs
 
-- Output from `/IWFND/ERROR_LOG` and `/IWFND/GW_CLIENT`. For more information, see the [SAP ABAP guide](https://www.youtube.com/watch?v=Tmb-O966GwM).
+- Output from `/IWFND/ERROR_LOG`. For more information, see the [ODATA Error Log Analysis video guide](https://www.youtube.com/watch?v=Tmb-O966GwM).
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a **Before Raising a Ticket** section to the on-premise README with three required pre-ticket steps: environment check, deployment prerequisites, and trace logging for failing OData services (linking to both Cloud Connector trace and ABAP transaction logs)
- Removes stale `/IWFND/GW_CLIENT` reference from `support-checklist.md`
- Updates the video guide link text in `support-checklist.md` to be consistent with `deployment.md`

## Test plan

- [ ] Review rendered markdown in GitHub
- [ ] Verify all links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)