### PR TITLE
docs: document samlAssertionEncoding property for SAML destination types

### DIFF
--- a/misc/s4hana/SAMLAssertionDestination.md
+++ b/misc/s4hana/SAMLAssertionDestination.md
@@ -35,6 +35,8 @@ The following screenshots show what the SAP BTP destination looks like once corr
 | `HTML5.DynamicDestination` | `true` |
 | `HTML5.Timeout` | `60000` |
 
+> **Note**: An additional optional property `samlAssertionEncoding` is available for `SAMLAssertion` destinations. It controls how the SAML assertion XML is encoded before being sent to the token service. Accepted values are `base64` (RFC 4648, section 4) and `base64url` (RFC 4648, section 5). If not set, the default is `base64` prior to the calendar week 24, 2026 Destination Service release (June 8 to 11, 2026) and `base64url` after. Set this property explicitly if your system requires a specific encoding to avoid unexpected behavior when the default changes. For more information, see [SAML Assertion Authentication](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/saml-assertion-authentication).
+
 ## License
 
 Copyright (c) 2009-2026 SAP SE or an SAP affiliate company. This project is licensed under the Apache Software License, version 2.0 except as noted otherwise in the [LICENSE](../../LICENSES/Apache-2.0.txt) file.

--- a/misc/successfactors/README.md
+++ b/misc/successfactors/README.md
@@ -130,6 +130,9 @@ If the proposed solution does not resolve the issue, re-establish the complete t
    | `WebIDEUsage` | `odata_gen` |
    | `HTML5.DynamicDestination` | `true` |
    | `product.name` | `SAP SuccessFactors` |
+   | `samlAssertionEncoding` | `base64` or `base64url` (optional — see note below) |
+
+   > **Note**: `samlAssertionEncoding` controls how the SAML assertion XML is encoded before being sent to the token service. Accepted values are `base64` (RFC 4648, section 4) and `base64url` (RFC 4648, section 5). If not set, the default is `base64` prior to the calendar week 24, 2026 Destination Service release (June 8 to 11, 2026) and `base64url` after. Set this property explicitly if your token service requires a specific encoding to avoid unexpected behavior when the default changes. For more information, see [OAuth SAML Bearer Assertion Authentication](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/oauth-saml-bearer-assertion-authentication).
 
 #### NameID Format
 


### PR DESCRIPTION
## Summary

- Adds `samlAssertionEncoding` optional additional property to the `OAuth2SAMLBearerAssertion` destination guide (`misc/successfactors/README.md`) — includes a new table row and note block
- Adds equivalent note to the `SAMLAssertion` destination guide (`misc/s4hana/SAMLAssertionDestination.md`)
- Both notes explain accepted values (`base64` / `base64url`), the CW24 2026 default-change behaviour, and link to the relevant SAP help documentation

## Test plan

- [ ] Markdown lint passes (`./scripts/lint-markdown.sh`) on both changed files
- [ ] Note content matches SAP help documentation for [SAML Assertion Authentication](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/saml-assertion-authentication) and [OAuth SAML Bearer Assertion Authentication](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/oauth-saml-bearer-assertion-authentication)
- [ ] KM review — Chicago title case, no em dashes in list items, correct terminology

🤖 Generated with [Claude Code](https://claude.com/claude-code)