### PR TITLE
fix: add /localService/ to deploy-to-abap exclude in travel app

### DIFF
--- a/V4/apps/travel/ui5-deploy.yaml
+++ b/V4/apps/travel/ui5-deploy.yaml
@@ -26,6 +26,7 @@ builder:
           transport: TR11111
         exclude:
           - /test/
+          - /localService/
   resources:
     excludes:
       - /test/**


### PR DESCRIPTION
## Summary

- Appends `/localService/` to the `exclude` list under the `deploy-to-abap` task in `V4/apps/travel/ui5-deploy.yaml`
- Prevents local mock service data from being uploaded during ABAP deployment
- Aligns with the existing `resources.excludes` entry which already excluded `/localService/**`