### PR TITLE
docs: clarify BAS vs VS Code authentication for SAP S/4HANA Cloud

### DIFF
--- a/misc/s4hana/README.md
+++ b/misc/s4hana/README.md
@@ -11,6 +11,27 @@
 5. You have reviewed [SAP S/4HANA Cloud, Public Edition FAQ](https://me.sap.com/notes/3445942).
 6. You have reviewed the [SAP Business Application Studio Integration with SAP S/4HANA Cloud](https://me.sap.com/notes/3297481) documentation.
 
+## Authentication Method by Development Tool
+
+The authentication method for connecting to SAP S/4HANA Cloud depends on the development tool you are using:
+
+| Development Tool | Authentication Type | Where to Configure |
+|---|---|---|
+| SAP Business Application Studio | `SAMLAssertion` | SAP BTP destination in your subaccount |
+| VS Code | `reentranceTicket` | `ui5.yaml` (preview) and `ui5-deploy.yaml` (deployment) |
+
+### SAP Business Application Studio
+
+SAP Business Application Studio connects to SAP S/4HANA Cloud through an SAP BTP destination configured with `SAMLAssertion` authentication. The destination is defined in your SAP BTP subaccount and uses federated identity to authenticate users without storing credentials.
+
+For configuration steps, see [Create a SAP BTP SAMLAssertion Destination to Consume V2 and V4 OData Catalogs](SAMLAssertionDestination.md).
+
+### VS Code
+
+VS Code connects directly to SAP S/4HANA Cloud using `reentranceTicket` authentication. The backend URL must point to the `-api` endpoint — for example, `https://my1111111-api.s4hana.ondemand.com`. You configure this directly in `ui5.yaml` for local preview and in `ui5-deploy.yaml` for deployment. Using the standard tenant URL without `-api` causes SAML redirect responses instead of OData responses.
+
+For more information, see [Issue 9: Troubleshooting Local VS Code Preview](#issue-9-local-vs-code-preview-returns-html-saml-login-page-instead-of-an-odata-response).
+
 ## Create a SAP BTP SAMLAssertion Destination to Consume V2 and V4 OData Catalogs
 
 For step-by-step instructions with screenshots, see [Create a SAP BTP SAMLAssertion Destination to Consume V2 and V4 OData Catalogs](SAMLAssertionDestination.md).

--- a/misc/s4hana/SAMLAssertionDestination.md
+++ b/misc/s4hana/SAMLAssertionDestination.md
@@ -1,5 +1,7 @@
 # Create a SAP BTP SAMLAssertion Destination to Consume V2 and V4 OData Catalogs
 
+> **Note**: This guide applies to **SAP Business Application Studio**. If you are using VS Code, configure `reentranceTicket` authentication directly in `ui5.yaml` and `ui5-deploy.yaml` using the `-api` endpoint. For more information, see [Authentication Method by Development Tool](README.md#authentication-method-by-development-tool).
+
 1. Open the [s4hana-cloud_saml.json](s4hana-cloud_saml.json) file using a text editor or browser.
 2. Replace all instances of `my1111111` with your specific hostname.
 3. Log in to your SAP BTP subaccount, select the `Destinations` tab, and select `Import Destination`.


### PR DESCRIPTION
## Summary

- Adds **Authentication Method by Development Tool** section to `misc/s4hana/README.md` immediately after Prerequisites — makes it explicit at a glance that BAS requires `SAMLAssertion` and VS Code requires `reentranceTicket`
- Adds a BAS-only callout note to `SAMLAssertionDestination.md` with a pointer to VS Code guidance for users who land on that page

## Test Plan

- [ ] Verify the new overview table renders correctly in GitHub markdown
- [ ] Confirm the anchor link to Issue 9 resolves correctly
- [ ] Confirm the link from SAMLAssertionDestination.md back to README resolves correctly