### PR TITLE
docs: update debug commands to include NODE_DEBUG and tee log output

### DIFF
--- a/misc/cicd/README.md
+++ b/misc/cicd/README.md
@@ -1,41 +1,37 @@
-# Sample Configurations to improve ABAP deployment task
+# Sample Configurations to Improve ABAP Deployment Task
 
 > **Important**: Any scripts or commands in this guide that modify deployment configurations, environment variables, or CI/CD pipeline settings may change the behaviour of your system. Ensure all such changes are carried out with the authorization of your IT support team. Additionally, ensure your HTML5 application source files are under source control before making any modifications.
 
-Please refer to the following guide for more info;
-
-https://www.npmjs.com/package/@sap/ux-ui5-tooling
+For more information, see the [@sap/ux-ui5-tooling package on npm](https://www.npmjs.com/package/@sap/ux-ui5-tooling).
 
 ## Developers Note
 
-SAP Cloud Transport Management (CTMS) for deployment is a recommended solution for ABAP deployment. While manual deployments or the use of CLI tools are supported, the CI/CD process may run in non-SAP DevOps platforms, but deployment to SAP BTP should go through CTMS. 
+SAP Cloud Transport Management (CTMS) for deployment is a recommended solution for ABAP deployment. While manual deployments or the use of CLI tools are supported, the CI/CD process may run in non-SAP DevOps platforms, but deployment to SAP BTP should go through CTMS.
 
-You can integrate external CI/CD pipelines, eg. Azure DevOps or CircleCI, to CTMS via APIs or using [GitHub Actions](https://github.com/marketplace/actions/deploy-to-sap-btp-with-ctms). 
+You can integrate external CI/CD pipelines, eg. Azure DevOps or CircleCI, to CTMS via APIs or using [GitHub Actions](https://github.com/marketplace/actions/deploy-to-sap-btp-with-ctms).
 
 With CTMS, you have full control on the changes going through the landscape, and have a proper audit log to trace them if required.
 
-For more information, please refer to the following resources;
+For more information, see [SAP BTP Runtimes — My Personal Considerations and Preferences on Cloud](https://community.sap.com/t5/technology-blog-posts-by-sap/sap-btp-runtimes-my-personal-considerations-and-preferences-on-cloud/ba-p/14129510).
 
-https://community.sap.com/t5/technology-blog-posts-by-sap/sap-btp-runtimes-my-personal-considerations-and-preferences-on-cloud/ba-p/14129510
+## Using Environment Variables with a .env File
 
+Create a `.env` file in the root of your SAPUI5 project and append the following content:
 
-## Using environment variables using .env file
-
-Create a `.env` file in the root of your SAPUI5 project and append the following content;
 ```
 XYZ_USER=myusername
 XYZ_PASSWORD=mypassword
 ```
 
-Update `ui5-deploy.yaml` with the `credentials`, ensuring it's aligned with the existing root nodes, for example `target`;
+Update `ui5-deploy.yaml` with the `credentials`, ensuring it's aligned with the existing root nodes, for example `target`:
 
-```YAML
+```yaml
     configuration:
       yes: true
       failFast: true
       target:
         url: https://XYZ.sap-system.corp:44311
-        client: 200        
+        client: 200
       credentials:
         username: env:XYZ_USER
         password: env:XYZ_PASSWORD
@@ -43,78 +39,84 @@ Update `ui5-deploy.yaml` with the `credentials`, ensuring it's aligned with the 
 
 When you run `npm run deploy` or `npm run undeploy`, it will pick up the respective environment variables.
 
-Setting `env:` for the credentials is only required if you want to configure a `.env` file to load environment variables, otherwise you export them as normal;
+Setting `env:` for the credentials is only required if you want to configure a `.env` file to load environment variables, otherwise you export them as normal:
 
 ```bash
 export XYZ_USER='~username'
-export XYZ_PASSWORD='~password''
+export XYZ_PASSWORD='~password'
 ```
 
-`ui5-deploy.yaml` is then updated as 
-```YAML
+`ui5-deploy.yaml` is then updated as:
+
+```yaml
       credentials:
         username: XYZ_USER
         password: XYZ_PASSWORD
 ```
 
-Or if using CLI params;
+Or if using CLI params:
+
 ```bash
---username XYZ_USER --pasword XYZ_PASSWORD
+--username XYZ_USER --password XYZ_PASSWORD
 ```
 
-Additional note, if you are using a CI/CD pipeline, then you can make further updates to your `ui5-deploy.yaml` as shown above;
+Note: if you are using a CI/CD pipeline, then you can make further updates to your `ui5-deploy.yaml` as shown above:
+
 - Add `yes: true` to bypass the `Yes` confirmation prompt
 - Add `failFast: true` to immediately exit the process if any exception is thrown, for example, a typical scenario is where authentication might fail, and you want to disable the credentials prompts from being shown. This will exit with code of `1`.
 
 ## Create Transport Request (TR) Dynamically
 
-To create a TR dynamically during each deploy or undeploy task, append the `REPLACE_WITH_TRANSPORT` bookmark to your `ui5-deploy.yaml` configuration;
-```YAML
+To create a TR dynamically during each deploy or undeploy task, append the `REPLACE_WITH_TRANSPORT` bookmark to your `ui5-deploy.yaml` configuration:
+
+```yaml
       app:
         name: /TEST/SAMPLE_APP
         package: /TEST/UPLOAD
         transport: REPLACE_WITH_TRANSPORT
 ```
 
-Using the TR `REPLACE_WITH_TRANSPORT` bookmark for undeployment works as well, for example, when you run `npm run undeploy` it will also creat a TR on the fly.
+Using the TR `REPLACE_WITH_TRANSPORT` bookmark for undeployment works as well, for example, when you run `npm run undeploy` it will also create a TR on the fly.
 
 ## CI/CD Pipeline
 
-Generate CLI commands for your CI/CD pipeline;
+Generate CLI commands for your CI/CD pipeline:
 
 ```bash
 npx fiori deploy --url https://your-env.hana.ondemand.com --name 'SAMPLE_APP' --package 'MY_PACKAGE' --transport 'REPLACE_WITH_TRANSPORT' --archive-path 'archive.zip' --username 'env:XYZ_USER' --password 'env:XYZ_PASSWORD' --noConfig --failFast --yes
 ```
 
-## Generate ZIP archive
+## Generate ZIP Archive
 
-You have two options;
+You have two options:
 
 ### Option 1
 
-Remove `--archive-path 'archive.zip'` from the CLI params and allow the `dist` folder to be archived on the fly during deployment 
+Remove `--archive-path 'archive.zip'` from the CLI params and allow the `dist` folder to be archived on the fly during deployment.
 
-### Option 2 
+### Option 2
 
-Generate an `archive.zip` manually which will require some updates to your existing project; update `package.json` with a new `devDependency`;
+Generate an `archive.zip` manually which will require some updates to your existing project; update `package.json` with a new `devDependency`:
+
 ```json
 "ui5-task-zipper": "latest"
 ```
 
-Update `ui5.yaml` with a new `builder` task;
-```YAML
+Update `ui5.yaml` with a new `builder` task:
+
+```yaml
 builder:
   customTasks:
     - name: ui5-task-zipper
       afterTask: generateVersionInfo
       configuration:
-        archiveName: "archive"          
+        archiveName: "archive"
         keepResources: true
 ```
 
-When `npm run build` is now executed, it will generate a new archive file `./dist/arhive.zip`.
+When `npm run build` is now executed, it will generate a new archive file `./dist/archive.zip`.
 
-You can also create a new configuration file called `build.yaml` to handle this specific task;
+You can also create a new configuration file called `build.yaml` to handle this specific task:
 
 ```yaml
 # yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
@@ -122,29 +124,32 @@ You can also create a new configuration file called `build.yaml` to handle this 
 specVersion: "3.1"
 metadata:
   name: <your-project-name>
-type: application  
+type: application
 builder:
   customTasks:
     - name: ui5-task-zipper
       afterTask: generateVersionInfo
       configuration:
-        archiveName: "archive"          
+        archiveName: "archive"
         keepResources: true
 ```
-Run the CLI command using the new `build.yaml` configuration;
+
+Run the CLI command using the new `build.yaml` configuration:
 
 ```bash
 npx ui5 build --config build.yaml
 ```
-which will generate a new archive file `./dist/arhive.zip`.
 
-Optionally, update your `scripts` in `package.json` with the new command;
+This will generate a new archive file `./dist/archive.zip`.
+
+Optionally, update your `scripts` in `package.json` with the new command:
 
 ```json
 "archive": "ui5 build --config build.yaml"
 ```
 
-Using either flow, you can see the new custom task `ui5-task-zipper` being executed;
+Using either flow, you can see the new custom task `ui5-task-zipper` being executed:
+
 ```bash
 info ProjectBuilder Preparing build for project project1
 info ProjectBuilder   Target directory: ./dist
@@ -160,27 +165,16 @@ info ProjectBuilder Build succeeded in 199 ms
 info ProjectBuilder Executing cleanup tasks...
 ```
 
-Note: please update your scripts to reflect the new target folder to `./dist/archive.zip`.
+Note: update your scripts to reflect the new target folder to `./dist/archive.zip`.
 
 ## Additional Notes
 
 1. For deployment purposes, appending additional headers is not supported via CLI or `ui5-deploy.yaml` configurations.
-2. If you want to enable debug mode, you can set the debug parameter as follows
+2. If you want to enable debug mode, set the `DEBUG` and `NODE_DEBUG` environment variables before running the deploy command. The output is also written to `deploy-debug.log` for easy sharing with support:
+
 ```bash
 # Using default npm scripts
-DEBUG=* npm run deloy
+DEBUG=* NODE_DEBUG=http,https,net,tls npm run deploy 2>&1 | tee deploy-debug.log
 # Or if you are using the CLI directly
-DEBUG=* npx fiori deploy ...
+DEBUG=* NODE_DEBUG=http,https,net,tls npx fiori deploy ... 2>&1 | tee deploy-debug.log
 ```
-
-
-
-
-
-
-
-
-
-
-
-

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -22,7 +22,7 @@ To use the OData service `/UI5/ABAP_REPOSITORY_SRV` to upload an SAPUI5 applicat
 - You have `S_DEVELOP` authorisation in your back-end system.
 - For SAP BTP destinations, ensure the `HTML5.Timeout` property is configured with a minimum value of `60000`.
 
-More information about `/UI5/ABAP_REPOSITORY_SRV` and completing these prerequisites can be found [here](https://ui5.sap.com/#/topic/a883327a82ef4cc792f3c1e7b7a48de8).
+For more information about `/UI5/ABAP_REPOSITORY_SRV` and completing these prerequisites, see the [UI5 ABAP Repository Service documentation](https://ui5.sap.com/#/topic/a883327a82ef4cc792f3c1e7b7a48de8).
 
 Any errors during deployment are reported in the HTTP status reports, either success or errors which may have occurred during the operation. The response header or the response body contains additional information, and below is a list of common issues when deploying to an ABAP target system.
 
@@ -35,17 +35,17 @@ Any errors during deployment are reported in the HTTP status reports, either suc
 
 Review the ABAP transaction log `/IWFND/ERROR_LOG` for missing authorization details and other back-end issues.
 
-To debug on the client side, capture verbose deployment output by setting the `DEBUG` environment variable before running the deploy command:
+To debug on the client side, capture verbose deployment output by setting the `DEBUG` and `NODE_DEBUG` environment variables before running the deploy command. The output is also written to `deploy-debug.log` for easy sharing with support:
 
 ```bash
 # Mac / Linux
-DEBUG=* npm run deploy
+DEBUG=* NODE_DEBUG=http,https,net,tls npm run deploy 2>&1 | tee deploy-debug.log
 
 # Windows (PowerShell)
-set DEBUG=* && npm run deploy
+$env:DEBUG="*"; $env:NODE_DEBUG="http,https,net,tls"; npm run deploy 2>&1 | Tee-Object deploy-debug.log
 ```
 
-**Resources**
+### Resources
 
 - [Deployment to ABAP On-Premise System](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:45996:50742:46000)
 - Video guide: [Analyzing the `/IWFND/ERROR_LOG` OData Error Log](https://www.youtube.com/watch?v=Tmb-O966GwM)


### PR DESCRIPTION
## Summary

- Updates debug deploy commands in `misc/cicd/README.md` and `misc/onpremise/deployment.md` to use `DEBUG=* NODE_DEBUG=http,https,net,tls npm run deploy 2>&1 | tee deploy-debug.log`
- Adds PowerShell equivalent (`Tee-Object`) in `deployment.md`
- The `tee` output makes it easier for customers to capture and attach logs to support tickets
- Also adds Google Cloud's browser trace capture guide as a reference alongside the existing SAP note

## Additional Fixes (pre-existing lint and KM issues in `misc/cicd/README.md`)

- Fixed duplicate "Using…Using" in heading
- Replaced bare URLs with descriptive link text
- Fixed trailing spaces, excess blank lines, missing blank lines around fences
- Fixed `YAML` → `yaml` fence language, typos (`deloy`, `arhive.zip`, `--pasword`)
- Converted `**Resources**` bold label to `### Resources` heading in `deployment.md`

## Test Plan

- [ ] Lint passes: `./scripts/lint-markdown.sh misc/cicd/README.md` and `misc/onpremise/deployment.md`
- [ ] Verify debug commands are correct and `tee deploy-debug.log` is present in both files