### PR TITLE
docs: add HTTP 502, 503, and 504 troubleshooting to deployment.md

### DIFF
--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -21,6 +21,12 @@ To use the OData service `/UI5/ABAP_REPOSITORY_SRV` to upload an SAPUI5 applicat
 - Activate the `/UI5/ABAP_REPOSITORY_SRV` service in your back-end system.
 - You have `S_DEVELOP` authorisation in your back-end system.
 - For SAP BTP destinations, ensure the `HTML5.Timeout` property is configured with a minimum value of `60000`.
+- For SAP BTP destinations, ensure the destination `URL` contains only the hostname — remove any service path or sub-path. The deployment tool appends the correct path automatically.
+
+  | | Example |
+  |---|---|
+  | **Correct** | `https://<hostname>` |
+  | **Incorrect** | `https://<hostname>/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` |
 
 For more information about `/UI5/ABAP_REPOSITORY_SRV` and completing these prerequisites, see the [UI5 ABAP Repository Service documentation](https://ui5.sap.com/#/topic/a883327a82ef4cc792f3c1e7b7a48de8).
 

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -34,7 +34,6 @@ Any errors during deployment are reported in the HTTP status reports, either suc
 - **HTTP 403 Forbidden** — authenticated but missing back-end authorization. Verify `S_DEVELOP` authorisation for your user.
 - **HTTP 502 Bad Gateway** — the gateway received an invalid response from the upstream ABAP back-end system. Common causes:
   - The back-end system or a reverse proxy in front of it (such as SAP Web Dispatcher) is not running or returning an unexpected response.
-  - The destination `URL` property points to an incorrect host or port, causing the request to reach the wrong service.
   - The destination `URL` includes a service path. The `URL` must contain only the host — the deployment tool appends the service path automatically. For example, use `https://<hostname>` and not `https://<hostname>/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`.
 
   Run `DEBUG=* npm run deploy` to expose the full request path in the output. Verify the URL and path match the expected back-end endpoint.
@@ -42,7 +41,7 @@ Any errors during deployment are reported in the HTTP status reports, either suc
   - The Cloud Connector cannot establish a secure tunnel to the back-end system, often caused by a local firewall or proxy. See [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526) and confirm [connectivity](./connectivity.md) before retrying.
   - The `HTML5.Timeout` destination property is too low and the request times out before the upload completes. Set it to a minimum of `60000`.
 
-Review the ABAP transaction log `/IWFND/ERROR_LOG` for missing authorization details and other back-end issues.
+Review the ABAP transaction log `/IWFND/ERROR_LOG` for missing authorization details and other back-end issues. See [ABAP Transaction Logs](./connectivity.md#abap-transaction-logs) for more information.
 
 To debug on the client side, capture verbose deployment output by setting the `DEBUG` and `NODE_DEBUG` environment variables before running the deploy command. The output is also written to `deploy-debug.log` for easy sharing with support:
 

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -39,9 +39,9 @@ Any errors during deployment are reported in the HTTP status reports, either suc
     | | Example |
     |---|---|
     | **Correct** | `https://<hostname>` |
-    | **Incorrect** | `https://<hostname>/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` |
+    | **Incorrect** | `https://<hostname>/sap/opu/odata/My/OdataService` |
 
-  Run `DEBUG=* npm run deploy` to expose the full request path in the output. Verify the URL and path match the expected back-end endpoint.
+  Run `DEBUG=* npm run deploy` to expose the full request path in the output. The path must match `https://<hostname>/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`.
 - **HTTP 503 Service Unavailable** — two common causes:
   - The Cloud Connector cannot establish a secure tunnel to the back-end system, often caused by a local firewall or proxy. See [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526) and confirm [connectivity](./connectivity.md) before retrying.
   - The `HTML5.Timeout` destination property is too low and the request times out before the upload completes. Set it to a minimum of `60000`.

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -5,7 +5,7 @@ This page covers how to deploy your SAP Fiori app to an on-premise ABAP reposito
 Table of Contents
 
 - [Prerequisites](#prerequisites)
-- [Debugging Deployment Errors (HTTP 401, HTTP 403, HTTP 502, and HTTP 503)](#debugging-deployment-errors-http-401-http-403-http-502-and-http-503)
+- [Debugging Deployment Errors (HTTP 401, HTTP 403, HTTP 502, HTTP 503, and HTTP 504)](#debugging-deployment-errors-http-401-http-403-http-502-http-503-and-http-504)
 - [Connection Test](#connection-test)
   - [What the Test Validates](#what-the-test-validates)
 - [Unknown File Type During Upload](#unknown-file-type-during-upload)
@@ -28,7 +28,7 @@ Any errors during deployment are reported in the HTTP status reports, either suc
 
 ---
 
-## Debugging Deployment Errors (HTTP 401, HTTP 403, HTTP 502, and HTTP 503)
+## Debugging Deployment Errors (HTTP 401, HTTP 403, HTTP 502, HTTP 503, and HTTP 504)
 
 - **HTTP 401 Unauthorized** — authentication failed. Check credentials, destination configuration, and trust setup.
 - **HTTP 403 Forbidden** — authenticated but missing back-end authorization. Verify `S_DEVELOP` authorisation for your user as described in [Prerequisites](#prerequisites).
@@ -41,10 +41,9 @@ Any errors during deployment are reported in the HTTP status reports, either suc
     | **Correct** | `https://<hostname>` |
     | **Incorrect** | `https://<hostname>/sap/opu/odata/My/OdataService` |
 
-  Run `DEBUG=* npm run deploy` to expose the full request path in the output. The path must match `https://<hostname>/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`.
-- **HTTP 503 Service Unavailable** — two common causes:
-  - The Cloud Connector cannot establish a secure tunnel to the back-end system, often caused by a local firewall or proxy. See [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526) and confirm [connectivity](./connectivity.md) before retrying.
-  - The `HTML5.Timeout` destination property is too low and the request times out before the upload completes. Set it to a minimum of `60000`.
+  Run `DEBUG=* npm run deploy` to expose the full request path in the output. The path must match `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`.
+- **HTTP 503 Service Unavailable** — the Cloud Connector cannot establish a secure tunnel to the back-end system, often caused by a local firewall or proxy. See [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526) and confirm [connectivity](./connectivity.md) before retrying.
+- **HTTP 504 Gateway Timeout** — the gateway did not receive a response from the back-end system in time. Increase the `HTML5.Timeout` destination property to a minimum of `60000` (milliseconds) as described in [Prerequisites](#prerequisites).
 
 Review the ABAP transaction log `/IWFND/ERROR_LOG` for missing authorization details and other back-end issues. See [ABAP Transaction Logs](./connectivity.md#abap-transaction-logs) for more information.
 

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -18,10 +18,10 @@ Table of Contents
 
 To use the OData service `/UI5/ABAP_REPOSITORY_SRV` to upload an SAPUI5 application, component, or library to the SAPUI5 ABAP repository, ensure the following requirements are met:
 
-- Activate the `/UI5/ABAP_REPOSITORY_SRV` service in your back-end system.
+- You have activated the `/UI5/ABAP_REPOSITORY_SRV` service in your back-end system.
 - You have `S_DEVELOP` authorisation in your back-end system.
-- For SAP BTP destinations, ensure the `HTML5.Timeout` property is configured with a minimum value of `60000`.
-- For SAP BTP destinations, ensure the destination `URL` contains only the hostname — remove any service path or sub-path. The deployment tool appends the correct path automatically.
+- You have set the `HTML5.Timeout` property to a minimum value of `60000` in your SAP BTP destination.
+- You have configured the SAP BTP destination `URL` to contain only the hostname, without a service path. The deployment tool appends the correct path automatically.
 
   | | Example |
   |---|---|
@@ -30,17 +30,17 @@ To use the OData service `/UI5/ABAP_REPOSITORY_SRV` to upload an SAPUI5 applicat
 
 For more information about `/UI5/ABAP_REPOSITORY_SRV` and completing these prerequisites, see the [UI5 ABAP Repository Service documentation](https://ui5.sap.com/#/topic/a883327a82ef4cc792f3c1e7b7a48de8).
 
-Any errors during deployment are reported in the HTTP status reports, either success or errors which may have occurred during the operation. The response header or the response body contains additional information, and below is a list of common issues when deploying to an ABAP target system.
+Any errors during deployment are reported in the HTTP status reports, either success or errors which may have occurred during the operation. The response header or the response body contains additional information. The following are common issues when deploying to an ABAP target system.
 
 ---
 
 ## Debugging Deployment Errors (HTTP 401, HTTP 403, HTTP 502, HTTP 503, and HTTP 504)
 
-- **HTTP 401 Unauthorized** — authentication failed. Check credentials, destination configuration, and trust setup.
-- **HTTP 403 Forbidden** — authenticated but missing back-end authorization. Verify `S_DEVELOP` authorisation for your user as described in [Prerequisites](#prerequisites).
-- **HTTP 502 Bad Gateway** — the gateway received an invalid response from the upstream ABAP back-end system. Common causes:
-  - The back-end system or a reverse proxy in front of it (such as SAP Web Dispatcher) is not running or returning an unexpected response.
-  - The destination `URL` includes a service path. Set the `URL` to the host address only — do not include a path after the hostname. The deployment tool adds the correct path automatically.
+- **HTTP 401 Unauthorized**: authentication failed. Check credentials, destination configuration, and trust setup.
+- **HTTP 403 Forbidden**: authenticated but missing back-end authorization. Verify `S_DEVELOP` authorisation for your user as described in [Prerequisites](#prerequisites).
+- **HTTP 502 Bad Gateway**: the gateway received an invalid response from the upstream ABAP back-end system. Common causes:
+  - The back-end system or a reverse proxy in front of it, such as SAP Web Dispatcher, is not running or returning an unexpected response.
+  - The destination `URL` includes a service path. Set the `URL` to the host address only. Do not include a path after the hostname. The deployment tool adds the correct path automatically.
 
     | | Example |
     |---|---|
@@ -48,10 +48,9 @@ Any errors during deployment are reported in the HTTP status reports, either suc
     | **Incorrect** | `https://<hostname>/sap/opu/odata/My/OdataService` |
 
   Run `DEBUG=* npm run deploy` to expose the full request path in the output. The path must match `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`.
-- **HTTP 503 Service Unavailable** — the most common deployment error. The Cloud Connector cannot establish a secure tunnel to the back-end system. Common causes:
+- **HTTP 503 Service Unavailable**: the most common deployment error. The Cloud Connector cannot establish a secure tunnel to the back-end system. Common causes:
   - A local firewall or proxy is blocking the connection. Confirm [connectivity](./connectivity.md) before retrying. See also [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526).
-  - The destination `URL` uses the wrong protocol. Verify the protocol matches what the back-end system expects — use `https://` unless the system is explicitly configured for `http://`.
-- **HTTP 504 Gateway Timeout** — the gateway did not receive a response from the back-end system in time. Increase the `HTML5.Timeout` destination property to a minimum of `60000` (milliseconds) as described in [Prerequisites](#prerequisites).
+- **HTTP 504 Gateway Timeout**: the gateway did not receive a response from the back-end system in time. Increase the `HTML5.Timeout` destination property to a minimum of `60000` milliseconds, as described in [Prerequisites](#prerequisites).
 
 Review the ABAP transaction log `/IWFND/ERROR_LOG` for missing authorization details and other back-end issues. See [ABAP Transaction Logs](./connectivity.md#abap-transaction-logs) for more information.
 

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -5,7 +5,7 @@ This page covers how to deploy your SAP Fiori app to an on-premise ABAP reposito
 Table of Contents
 
 - [Prerequisites](#prerequisites)
-- [Debugging Deployment Errors (HTTP 401, HTTP 403, and HTTP 503)](#debugging-deployment-errors-http-401-http-403-and-http-503)
+- [Debugging Deployment Errors (HTTP 401, HTTP 403, HTTP 502, and HTTP 503)](#debugging-deployment-errors-http-401-http-403-http-502-and-http-503)
 - [Connection Test](#connection-test)
   - [What the Test Validates](#what-the-test-validates)
 - [Unknown File Type During Upload](#unknown-file-type-during-upload)
@@ -28,10 +28,14 @@ Any errors during deployment are reported in the HTTP status reports, either suc
 
 ---
 
-## Debugging Deployment Errors (HTTP 401, HTTP 403, and HTTP 503)
+## Debugging Deployment Errors (HTTP 401, HTTP 403, HTTP 502, and HTTP 503)
 
 - **HTTP 401 Unauthorized** — authentication failed. Check credentials, destination configuration, and trust setup.
 - **HTTP 403 Forbidden** — authenticated but missing back-end authorization. Verify `S_DEVELOP` authorisation for your user.
+- **HTTP 502 Bad Gateway** — the SAP BTP destination received an invalid response from the back-end system or Cloud Connector. Common causes:
+  - The destination `URL` property points to an incorrect host or port.
+  - The Cloud Connector virtual host mapping is incorrect — verify the mapping in the Cloud Connector administration UI.
+  - The back-end system is unreachable or not running.
 - **HTTP 503 Service Unavailable** — two common causes:
   - The Cloud Connector cannot establish a secure tunnel to the back-end system, often caused by a local firewall or proxy. See [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526) and confirm [connectivity](./connectivity.md) before retrying.
   - The `HTML5.Timeout` destination property is too low and the request times out before the upload completes. Set it to a minimum of `60000`.

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -34,7 +34,12 @@ Any errors during deployment are reported in the HTTP status reports, either suc
 - **HTTP 403 Forbidden** — authenticated but missing back-end authorization. Verify `S_DEVELOP` authorisation for your user as described in [Prerequisites](#prerequisites).
 - **HTTP 502 Bad Gateway** — the gateway received an invalid response from the upstream ABAP back-end system. Common causes:
   - The back-end system or a reverse proxy in front of it (such as SAP Web Dispatcher) is not running or returning an unexpected response.
-  - The destination `URL` includes a service path. The `URL` must contain only the host — the deployment tool appends the service path automatically. For example, use `https://<hostname>` and not `https://<hostname>/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`.
+  - The destination `URL` includes a service path. Set the `URL` to the host address only — do not include a path after the hostname. The deployment tool adds the correct path automatically.
+
+    | | Example |
+    |---|---|
+    | **Correct** | `https://<hostname>` |
+    | **Incorrect** | `https://<hostname>/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` |
 
   Run `DEBUG=* npm run deploy` to expose the full request path in the output. Verify the URL and path match the expected back-end endpoint.
 - **HTTP 503 Service Unavailable** — two common causes:

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -48,7 +48,9 @@ Any errors during deployment are reported in the HTTP status reports, either suc
     | **Incorrect** | `https://<hostname>/sap/opu/odata/My/OdataService` |
 
   Run `DEBUG=* npm run deploy` to expose the full request path in the output. The path must match `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`.
-- **HTTP 503 Service Unavailable** — the Cloud Connector cannot establish a secure tunnel to the back-end system, often caused by a local firewall or proxy. See [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526) and confirm [connectivity](./connectivity.md) before retrying.
+- **HTTP 503 Service Unavailable** — the most common deployment error. The Cloud Connector cannot establish a secure tunnel to the back-end system. Common causes:
+  - A local firewall or proxy is blocking the connection. Confirm [connectivity](./connectivity.md) before retrying. See also [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526).
+  - The destination `URL` uses the wrong protocol. Verify the protocol matches what the back-end system expects — use `https://` unless the system is explicitly configured for `http://`.
 - **HTTP 504 Gateway Timeout** — the gateway did not receive a response from the back-end system in time. Increase the `HTML5.Timeout` destination property to a minimum of `60000` (milliseconds) as described in [Prerequisites](#prerequisites).
 
 Review the ABAP transaction log `/IWFND/ERROR_LOG` for missing authorization details and other back-end issues. See [ABAP Transaction Logs](./connectivity.md#abap-transaction-logs) for more information.

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -32,10 +32,9 @@ Any errors during deployment are reported in the HTTP status reports, either suc
 
 - **HTTP 401 Unauthorized** — authentication failed. Check credentials, destination configuration, and trust setup.
 - **HTTP 403 Forbidden** — authenticated but missing back-end authorization. Verify `S_DEVELOP` authorisation for your user.
-- **HTTP 502 Bad Gateway** — the SAP BTP destination received an invalid response from the back-end system or Cloud Connector. Common causes:
-  - The destination `URL` property points to an incorrect host or port.
-  - The Cloud Connector virtual host mapping is incorrect — verify the mapping in the Cloud Connector administration UI.
-  - The back-end system is unreachable or not running.
+- **HTTP 502 Bad Gateway** — the gateway received an invalid response from the upstream ABAP back-end system. Common causes:
+  - The back-end system or a reverse proxy in front of it (such as SAP Web Dispatcher) is not running or returning an unexpected response.
+  - The destination `URL` property points to an incorrect host or port, causing the request to reach the wrong service.
 - **HTTP 503 Service Unavailable** — two common causes:
   - The Cloud Connector cannot establish a secure tunnel to the back-end system, often caused by a local firewall or proxy. See [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526) and confirm [connectivity](./connectivity.md) before retrying.
   - The `HTML5.Timeout` destination property is too low and the request times out before the upload completes. Set it to a minimum of `60000`.

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -31,7 +31,7 @@ Any errors during deployment are reported in the HTTP status reports, either suc
 ## Debugging Deployment Errors (HTTP 401, HTTP 403, HTTP 502, and HTTP 503)
 
 - **HTTP 401 Unauthorized** — authentication failed. Check credentials, destination configuration, and trust setup.
-- **HTTP 403 Forbidden** — authenticated but missing back-end authorization. Verify `S_DEVELOP` authorisation for your user.
+- **HTTP 403 Forbidden** — authenticated but missing back-end authorization. Verify `S_DEVELOP` authorisation for your user as described in [Prerequisites](#prerequisites).
 - **HTTP 502 Bad Gateway** — the gateway received an invalid response from the upstream ABAP back-end system. Common causes:
   - The back-end system or a reverse proxy in front of it (such as SAP Web Dispatcher) is not running or returning an unexpected response.
   - The destination `URL` includes a service path. The `URL` must contain only the host — the deployment tool appends the service path automatically. For example, use `https://<hostname>` and not `https://<hostname>/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`.

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -35,6 +35,7 @@ Any errors during deployment are reported in the HTTP status reports, either suc
 - **HTTP 502 Bad Gateway** — the gateway received an invalid response from the upstream ABAP back-end system. Common causes:
   - The back-end system or a reverse proxy in front of it (such as SAP Web Dispatcher) is not running or returning an unexpected response.
   - The destination `URL` property points to an incorrect host or port, causing the request to reach the wrong service.
+  - The destination `URL` includes a service path. The `URL` must contain only the host — the deployment tool appends the service path automatically. For example, use `https://<hostname>` and not `https://<hostname>/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`.
 
   Run `DEBUG=* npm run deploy` to expose the full request path in the output. Verify the URL and path match the expected back-end endpoint.
 - **HTTP 503 Service Unavailable** — two common causes:

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -5,7 +5,7 @@ This page covers how to deploy your SAP Fiori app to an on-premise ABAP reposito
 Table of Contents
 
 - [Prerequisites](#prerequisites)
-- [Debugging Deployment Errors (HTTP 401 and HTTP 403)](#debugging-deployment-errors-http-401-and-http-403)
+- [Debugging Deployment Errors (HTTP 401, HTTP 403, and HTTP 503)](#debugging-deployment-errors-http-401-http-403-and-http-503)
 - [Connection Test](#connection-test)
   - [What the Test Validates](#what-the-test-validates)
 - [Unknown File Type During Upload](#unknown-file-type-during-upload)
@@ -28,10 +28,13 @@ Any errors during deployment are reported in the HTTP status reports, either suc
 
 ---
 
-## Debugging Deployment Errors (HTTP 401 and HTTP 403)
+## Debugging Deployment Errors (HTTP 401, HTTP 403, and HTTP 503)
 
 - **HTTP 401 Unauthorized** — authentication failed. Check credentials, destination configuration, and trust setup.
 - **HTTP 403 Forbidden** — authenticated but missing back-end authorization. Verify `S_DEVELOP` authorisation for your user.
+- **HTTP 503 Service Unavailable** — two common causes:
+  - The Cloud Connector cannot establish a secure tunnel to the back-end system, often caused by a local firewall or proxy. See [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526) and confirm [connectivity](./connectivity.md) before retrying.
+  - The `HTML5.Timeout` destination property is too low and the request times out before the upload completes. Set it to a minimum of `60000`.
 
 Review the ABAP transaction log `/IWFND/ERROR_LOG` for missing authorization details and other back-end issues.
 

--- a/misc/onpremise/deployment.md
+++ b/misc/onpremise/deployment.md
@@ -35,6 +35,8 @@ Any errors during deployment are reported in the HTTP status reports, either suc
 - **HTTP 502 Bad Gateway** — the gateway received an invalid response from the upstream ABAP back-end system. Common causes:
   - The back-end system or a reverse proxy in front of it (such as SAP Web Dispatcher) is not running or returning an unexpected response.
   - The destination `URL` property points to an incorrect host or port, causing the request to reach the wrong service.
+
+  Run `DEBUG=* npm run deploy` to expose the full request path in the output. Verify the URL and path match the expected back-end endpoint.
 - **HTTP 503 Service Unavailable** — two common causes:
   - The Cloud Connector cannot establish a secure tunnel to the back-end system, often caused by a local firewall or proxy. See [Invalid proxy response status: 503 Service Unavailable](https://ga.support.sap.com/index.html#/tree/3046/actions/45995:48363:53594:63697:48366:52526) and confirm [connectivity](./connectivity.md) before retrying.
   - The `HTML5.Timeout` destination property is too low and the request times out before the upload completes. Set it to a minimum of `60000`.

--- a/misc/onpremise/support-checklist.md
+++ b/misc/onpremise/support-checklist.md
@@ -37,7 +37,7 @@ Collected trace logs (see [Enable Cloud Connector Trace Logging](./connectivity.
 
 ### ABAP Transaction Logs
 
-- Output from `/IWFND/ERROR_LOG`. For more information, see the [ODATA Error Log Analysis video guide](https://www.youtube.com/watch?v=Tmb-O966GwM).
+- Output from the ABAP transaction log `/IWFND/ERROR_LOG`. For instructions on accessing this log, see [ABAP Transaction Logs](./connectivity.md#abap-transaction-logs).
 
 ---
 


### PR DESCRIPTION
## Summary

- Expand the deployment error section to cover HTTP 502, 503, and 504 (previously only 401 and 403)
- Add hostname-only destination URL rule to Prerequisites with a correct/incorrect table
- HTTP 502: upstream ABAP/web dispatcher returning invalid response; includes `DEBUG=*` guidance to verify the request path matches `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`
- HTTP 503: most common deployment error — Cloud Connector tunnel failure (firewall/proxy) or wrong protocol (`http` vs `https`)
- HTTP 504: correctly attributed to `HTML5.Timeout` too low (previously misclassified under 503)
- Cross-link HTTP 403 back to Prerequisites for `S_DEVELOP` authorisation
- Cross-link `/IWFND/ERROR_LOG` reference to `connectivity.md#abap-transaction-logs`
- Fix `support-checklist.md`: "ODATA" → "OData", replace YouTube link with cross-link to `connectivity.md#abap-transaction-logs`

## Test Plan

- [ ] Verify all internal anchor links resolve correctly
- [ ] Confirm correct/incorrect tables render in markdown preview
- [ ] Confirm all external links are reachable