### PR TITLE
docs: clarify service key as source of OAuth2 credentials in ABAP Cloud destination

### DIFF
--- a/misc/abapcloud/README.md
+++ b/misc/abapcloud/README.md
@@ -63,6 +63,8 @@ The following is an example of an `OAuth2UserTokenExchange` destination for an A
 }
 ```
 
+> **Note**: The `clientId`, `clientSecret`, and `tokenServiceURL` values are obtained from the service key of your ABAP Environment instance. To generate a service key, open the SAP BTP cockpit, navigate to your ABAP Environment service instance, and create a new service key. The `clientId` and `clientSecret` are available in the service key JSON under the `uaa` object. The `tokenServiceURL` is the `uaa.url` value with `/oauth/token` appended.
+
 > **Note**: `OAuth2UserTokenExchange` exchanges an existing user access token for a new token scoped to a target service, which preserve the user context within OAuth flows. `SAMLAssertion` uses a signed XML assertion from an identity provider to authenticate the user and establish trust, typically in cross-system or federated SSO scenarios. Both types can be used within the same subaccount.
 
 Alternatively, `SAMLAssertion` can be used for both same-subaccount and cross-subaccount scenarios. See the following example:


### PR DESCRIPTION
## Summary

- Adds a note to the `OAuth2UserTokenExchange` destination example in `misc/abapcloud/README.md` clarifying that `clientId`, `clientSecret`, and `tokenServiceURL` are obtained from the ABAP Environment instance service key
- Explains that `clientId` and `clientSecret` are found under the `uaa` object in the service key JSON
- Explains that `tokenServiceURL` is the `uaa.url` value with `/oauth/token` appended

## Test Plan

- [ ] Verify note renders correctly in GitHub markdown preview
- [ ] Confirm all three properties (`clientId`, `clientSecret`, `tokenServiceURL`) are mentioned and accurately described