### PR TITLE
chore: add resources.excludes to V4 travel ui5.yaml and ui5-local.yaml

### DIFF
--- a/V4/apps/travel/ui5-local.yaml
+++ b/V4/apps/travel/ui5-local.yaml
@@ -60,3 +60,7 @@ builder:
         debug: true
         transformModulesToUI5:
           overridesToOverride: true
+  resources:
+    excludes:
+      - /test/**
+      - /localService/**

--- a/V4/apps/travel/ui5.yaml
+++ b/V4/apps/travel/ui5.yaml
@@ -46,3 +46,7 @@ builder:
         debug: true
         transformModulesToUI5:
           overridesToOverride: true
+  resources:
+    excludes:
+      - /test/**
+      - /localService/**


### PR DESCRIPTION
## Summary

- Adds `resources.excludes` block to `ui5.yaml` and `ui5-local.yaml` in V4 travel app
- Excludes `/test/**` and `/localService/**` from builds, matching `ui5-deploy.yaml`

## Test Plan

- [ ] CI passes