### PR TITLE
chore: add CODEOWNERS for admin team merge rights

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# All files owned by the admin team.
+# Members of this team can merge PRs once all status checks pass — no separate approver required.
+* @SAP-samples/fiori-tools-samples-admin


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` assigning `@SAP-samples/fiori-tools-samples-admin` as owners of all files
- Sets `required_approving_review_count` to `0` so admins can merge once all CI checks pass — no separate approver needed
- PRs still require all status checks to pass before merge is allowed

## Effect

Members of `fiori-tools-samples-admin` (`ianquigley-sap`, `Klaus-Keller`) can now merge any green PR without waiting for a reviewer.