### PR TITLE
docs(abapcloud): add CI/CD deploy flow and MFA troubleshooting

### DIFF
--- a/misc/abapcloud/README.md
+++ b/misc/abapcloud/README.md
@@ -152,9 +152,32 @@ npx fiori deploy \
   --uaa-password '<password>' \
   --uaa-clientid '<uaa-client-id>' \
   --uaa-clientsecret '<uaa-client-secret>' \
-  --noConfig
+  --noConfig \
+  --yes \
+  --verbose \
+  --failfast
 ```
 
+To undeploy an application, use the same approach with `npx fiori undeploy`. The `--package` and `--archive-path` parameters are not required for undeployment:
+
+```bash
+npx fiori undeploy \
+  --url 'https://<abap-system-guid>.abap.<region>.ondemand.com' \
+  --name '<app-name>' \
+  --transport '<transport-request>' \
+  --uaa-url 'https://<subdomain>.authentication.<region>.hana.ondemand.com' \
+  --uaa-username '<username>' \
+  --uaa-password '<password>' \
+  --uaa-clientid '<uaa-client-id>' \
+  --uaa-clientsecret '<uaa-client-secret>' \
+  --noConfig \
+  --yes \
+  --verbose \
+  --failfast
+```
+
+> **Note**: If a `ui5-deploy.yaml` configuration file is present, you can omit `--noConfig` and the `--name`, `--package`, and `--transport` parameters. The command reads those values from the configuration file automatically.
+>
 > **Note**: Values that contain special characters such as `!`, `/`, `+`, or `=`, which are common in UAA client IDs and secrets, must be quoted. In bash, use single quotes (`'value'`) to prevent the shell from interpreting these characters.
 
 For more information about CI/CD deployment configuration, which includes common errors such as MFA enforcement, see the [CI/CD README](../cicd/README.md).

--- a/misc/abapcloud/README.md
+++ b/misc/abapcloud/README.md
@@ -136,6 +136,29 @@ Use the Environment Check tool in SAP Business Application Studio to validate yo
 
 If you are still facing issues after reviewing the Environment Check report, enable a connectivity trace in your ABAP Cloud system and analyze the error. For more information, see [Enable a Connectivity Trace](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/display-connectivity-trace).
 
+## CI/CD Deployment
+
+To deploy from a CI/CD pipeline without a `ui5-deploy.yaml` configuration file, use the `--noConfig` flag and pass all required parameters directly on the command line:
+
+```bash
+npx fiori deploy \
+  --url 'https://<abap-system-guid>.abap.<region>.ondemand.com' \
+  --name '<app-name>' \
+  --package '<abap-package>' \
+  --transport '<transport-request>' \
+  --archive-path 'archive.zip' \
+  --uaa-url 'https://<subdomain>.authentication.<region>.hana.ondemand.com' \
+  --uaa-username '<username>' \
+  --uaa-password '<password>' \
+  --uaa-clientid '<uaa-client-id>' \
+  --uaa-clientsecret '<uaa-client-secret>' \
+  --noConfig
+```
+
+> **Note**: Values that contain special characters such as `!`, `/`, `+`, or `=`, which are common in UAA client IDs and secrets, must be quoted. In bash, use single quotes (`'value'`) to prevent the shell from interpreting these characters.
+
+For more information about CI/CD deployment configuration, which includes common errors such as MFA enforcement, see the [CI/CD README](../cicd/README.md).
+
 ## License
 
 Copyright (c) 2009-2026 SAP SE or an SAP affiliate company. This project is licensed under the Apache Software License, version 2.0 except as noted otherwise in the [LICENSE](../../LICENSES/Apache-2.0.txt) file.

--- a/misc/cicd/README.md
+++ b/misc/cicd/README.md
@@ -98,6 +98,19 @@ Generate CLI commands for your CI/CD pipeline:
 npx fiori deploy --url https://your-env.hana.ondemand.com --name 'SAMPLE_APP' --package 'MY_PACKAGE' --transport 'REPLACE_WITH_TRANSPORT' --archive-path 'archive.zip' --username 'env:XYZ_USER' --password 'env:XYZ_PASSWORD' --noConfig --failFast --yes
 ```
 
+### MFA Error
+
+If the deployment fails with the following error, MFA is enforced on the UAA user and the password grant flow cannot satisfy the MFA requirement:
+
+```json
+{
+    "error": "invalid_client",
+    "error_description": "{\"error\":\"invalid_grant\",\"error_description\":\"User authentication failed: INVALID_OTP_CODE\"}"
+}
+```
+
+Many identity providers do not support `grant_type=password` when MFA is required. To resolve this, an administrator must disable MFA for the user or exclude them from the MFA policy in the identity provider being used. MFA is controlled by the identity provider, such as SAP IAS, Microsoft Entra ID, or Keycloak, and not by ABAP Cloud itself. For more information about disabling MFA in SAP IAS, see [SAP Note 3715393](https://me.sap.com/notes/0003715393).
+
 ## Generate a ZIP Archive
 
 ### Option 1


### PR DESCRIPTION
## Summary

- Adds a CI/CD deployment section to `misc/abapcloud/README.md` with a parameterized `npx fiori deploy` command using `--noConfig`, with a note on quoting special characters
- Adds an MFA error troubleshooting subsection to `misc/cicd/README.md` with the exact error JSON, identity provider context, and a link to SAP Note 3715393
- Links the ABAP Cloud README to the CI/CD README for full detail — no duplication
- Applies KM review fixes (banned words, parenthetical style, link phrasing)

## Test plan

- [ ] Verify `misc/abapcloud/README.md` CI/CD section renders correctly
- [ ] Verify `misc/cicd/README.md` MFA Error subsection renders correctly
- [ ] Confirm relative link `../cicd/README.md` resolves on GitHub
- [ ] Confirm SAP Note link is correct